### PR TITLE
Add TODOs.md, starting with the Astro site

### DIFF
--- a/TODOs.md
+++ b/TODOs.md
@@ -1,0 +1,35 @@
+# TODOs
+
+Things queued for this repo.  Not a backlog — if something sits here for months it should be deleted rather than carried.
+
+---
+
+## Publish about-me as a small Astro site
+
+**Status:** queued, ~1–2 weeks out (noted 2026-08-22)
+
+Right now this repo *is* the site: people read it on GitHub.  That's fine for a leadership doc and increasingly wrong for [fnr/](fnr/), which is a weekly publication and deserves to look like one.
+
+**What already exists:** a Netlify site, `iridescent-meerkat-f04954`, on my personal account, already connected to this repo.  It currently 404s because there's no build — Netlify has nothing to serve from a pile of markdown.  So the plumbing is done; only the site is missing.
+
+### Rough shape
+
+- **Astro, content collections over the existing markdown.**  Don't restructure the repo to suit the site.  The markdown stays the source of truth and stays readable on GitHub; Astro reads it where it lives.  If the site ever requires moving files around, the site is wrong.
+- **Three surfaces, different jobs:**
+  - `fnr/` → the weekly.  Index page, individual entries, chronological archive.  This is the part that most needs to stop being a directory listing.
+  - `README.md` + `leadership/` + `ideas/` → the evergreen material.  Slow-changing, deep-linkable.
+  - `past/` → archive.  Present, findable, visibly not current.
+- **A feed is the point, not a nice-to-have.**  A weekly with no RSS/Atom is a folder people forget to check.  This is most of the argument for building the site at all.
+- **Rename the Netlify site.**  `iridescent-meerkat-f04954` was auto-generated and never touched.  Decide on a custom domain at the same time, or explicitly decide not to.
+
+### Watch out for
+
+- **`fnr/.private/` must never reach the build output.**  It's gitignored so it won't be in a clean checkout, but any local build would see it.  Add an explicit exclude rather than relying on gitignore, and check `dist/` before the first deploy.
+- **Don't break inbound GitHub links.**  Plenty of things point at `github.com/batmany13/about-me/...` — talks, the LinkedIn profile, `speaking/external_presence.md`.  The repo staying readable is a feature; the site is additive.
+- **Keep the weekly's authoring flow untouched.**  The [fnr skill](.claude/skills/fnr/SKILL.md) writes markdown to `fnr/<YYYY-WNN>.md`.  The site should build from that with no extra step, or the habit acquires friction and dies.
+
+### Open questions
+
+- Custom domain, or live on a Netlify subdomain for now?
+- Does the weekly want an email list eventually, or is a feed enough?
+- Anything here that shouldn't be on a real website — the site makes this material meaningfully more discoverable than a GitHub repo does, and that's worth one deliberate pass before launch rather than after.


### PR DESCRIPTION
Captures the plan to publish this repo as a small Astro site, while it's fresh. Independent of #6 — no overlapping files, merges in either order.

**The case for it:** the repo currently *is* the site. That works for the leadership material and works badly for `fnr/`, which is a weekly publication currently rendered as a GitHub directory listing.

**The plumbing already exists.** The Netlify site `iridescent-meerkat-f04954` is connected to this repo and 404s because there's no build — Netlify has nothing to serve from markdown. So this is a site-building task, not a setup task.

**Shape recorded in the file:**
- Astro content collections reading the existing markdown *where it lives* — if the site ever requires restructuring the repo, the site is wrong
- Three surfaces with different jobs: the weekly, the evergreen material, the archive
- A feed is most of the argument for building it at all — a weekly with no RSS is a folder people forget to check
- Rename the auto-generated Netlify site, and decide on a domain or explicitly decide not to

**Three things to watch, also in the file:** `fnr/.private/` must never reach the build output (gitignored, but a local build would see it — exclude explicitly and check `dist/` before the first deploy); inbound `github.com/batmany13/about-me/...` links stay alive; and the weekly's authoring flow doesn't acquire a new step, or the habit picks up friction and dies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)