### PR TITLE
DeepVista as the control: read the week's cards back, and roll it up

### DIFF
--- a/.claude/skills/catchup/SKILL.md
+++ b/.claude/skills/catchup/SKILL.md
@@ -627,14 +627,28 @@ uv run $SKILL/deepvista_cards.py record --repo . --id <entity-id> --card-id <ret
 The free tier is 100 credits a month, and re-pushing an unchanged card spends
 one to change nothing.
 
-## Step 5b (optional): Read the week back from DeepVista
+## Step 5b (optional): Read the week back from DeepVista — the control
 
 Only where the sync is on and the week has been pushed. The cards hold the same
-entities, so DeepVista is a second reader of the same evidence — fetch the
-week's cards, have a summary written from them, and diff the coverage:
+entities, so DeepVista is a second reader of the same evidence. Reading them
+back is scripted and **headless**: once the `mcp-remote` proxy has cached a
+sign-in, `fetch` spawns it and pulls the week's cards into one file, with a
+fidelity read per card.
 
 ```bash
-uv run $SKILL/deepvista_cards.py compare <week> --repo . --against dv-summary.md
+uv run $SKILL/deepvista_cards.py fetch --repo . --week 2026-W35 --out deepvista-cards.json
+```
+
+It reports, per card, whether the `<!-- catchup-entity -->` tracer survived
+(`intact` / `escaped` / `missing`) and whether the body is what the entity
+renders to now (`matches` / `cosmetic` / `differs`) — and, for the repo as a
+whole, entities never pushed, cards the store has forgotten (**orphans** under
+the `repo:` tag, which is what a rename after a push leaves behind), and cards
+that no longer exist. Then have a summary written **from that file alone**, in
+this skill's own shape, and diff the coverage:
+
+```bash
+uv run $SKILL/deepvista_cards.py compare <week> --repo . --against deepvista-summary.md
 ```
 
 The two buckets worth reading are **only the DeepVista summary** (the local one
@@ -642,6 +656,14 @@ left something out — judgment or omission?) and **covered by neither** (both
 writers passed over it independently, which is either agreement or a shared
 blind spot). Pull the better version *by entity*, into the local file — that is
 the one under version control and the one the scrub policy has been applied to.
+
+**Where this normally runs is the aggregator, not here.** A repo can run its own
+read, but the cross-repo `rollup` runs `fetch` and `compare` for every repo that
+syncs, in one pass, and files the results beside the sources it snapshotted —
+so the control lands where the week is read across repos, and one summary of
+the summaries can say what each reader missed. This skill keeps the two
+commands because the repo that owns the entities owns the read of them; the
+rollup calls this script *in that repo* rather than re-implementing it.
 
 ## Step 6: Report
 

--- a/.claude/skills/catchup/reference/deepvista.md
+++ b/.claude/skills/catchup/reference/deepvista.md
@@ -3,9 +3,11 @@
 Pushes catchup **entities** into [DeepVista](https://deepvista.ai) as context
 cards. Off unless a repo's config sets `deepvista.enabled: true`.
 
-Status: **prototype.** The card shape and the create/update/skip cycle are
-built and tested locally; what has not been exercised is a live account. The
-open questions are listed at the bottom.
+Status: **live, both directions.** The push was exercised against a live
+account on 2026-09-02 (see *First live push*), and the read-back — `fetch`,
+headless through the proxy — the same day, on 74 cards across two repos (see
+*Reading the week back*). The push half is still model-driven; the read half
+is a script.
 
 ## Why one card per entity
 
@@ -218,14 +220,65 @@ Once a week's cards are pushed, DeepVista holds the same entities the local
 store does — which makes it a second reader of the same evidence, and a way to
 find out what the local summary missed.
 
-1. Fetch the week's cards through the MCP search tool
-   (`tag:repo:<label>` plus the week), and have the model write a summary from
-   what comes back, in the format `SKILL.md` describes. Save it to a file.
-2. Diff the coverage:
+1. Fetch the week's cards — scripted, and headless once the proxy has a token:
 
 ```bash
-uv run scripts/deepvista_cards.py compare 2026-W35 --repo . --against dv-summary.md
+uv run scripts/deepvista_cards.py fetch --repo . --week 2026-W35 --out deepvista-cards.json
 ```
+
+2. Have a summary written from that file **alone**, in the format `SKILL.md`
+   describes, without the local summary or the store open. Save it beside it.
+3. Diff the coverage:
+
+```bash
+uv run scripts/deepvista_cards.py compare 2026-W35 --repo . --against deepvista-summary.md
+```
+
+### How `fetch` reads headlessly
+
+`fetch` spawns `npx -y mcp-remote <endpoint>` itself and speaks JSON-RPC to it
+over stdio — the same proxy the `.mcp.json` entry names, started by the script
+rather than by the host app. That works without a human because the proxy
+caches its OAuth token under `~/.mcp-auth` after one browser sign-in; from then
+on any process that starts it gets a session. Three things learned making it
+run:
+
+- **The cache can be half-finished.** `~/.mcp-auth/mcp-remote-v1/` held a
+  `_client_info.json` and a `_code_verifier` but no `_tokens.json` — a sign-in
+  that was started and never completed. That looks cached and is not. The
+  tokens file is the thing to look for; when it is absent, the proxy prints the
+  authorization URL and waits, and `fetch` surfaces that URL rather than timing
+  out silently.
+- **PATH's `npx` is not necessarily the one that can run it.** The machine this
+  was built on had npm 6's `npx` first on PATH and npm 11's under Homebrew.
+  `fetch` resolves an `npx` of version 7+ across PATH and the well-known install
+  locations for its *own* subprocess — that path is never written into a repo
+  file, so it can be machine-specific in a way `.mcp.json` cannot.
+- **A session can go missing between `initialize` and the first call.** The
+  client re-initializes once on the same proxy before giving up, and the output
+  records `session_reinits` so a run that needed it is distinguishable from one
+  that did not.
+
+### What the read reports, and what each state means
+
+The read is a fidelity check on the push as much as a second summary. Per card:
+
+| Field | States | Meaning |
+|---|---|---|
+| `tracer` | `intact` / `escaped` / `missing` | Whether the `<!-- catchup-entity -->` comment still points at its entity. `escaped` is the links-only pass's HTML-escaping (see the gotchas) — still the right card, no longer byte-identical |
+| `body` | `matches` / `cosmetic` / `differs` | Against what the entity renders to now. `cosmetic` is markdown escaping and blank lines the bridge did not send (`*[grade]*` back as `*\[grade\]*`) — content-identical, normalised away. `differs` with `store_current: true` is the one to look at; with the store moved on it is the ordinary post-push edit and `plan` will say `update` |
+
+And per repo: **unpushed** entities of the week, **orphans** — cards under the
+`repo:` tag that no entity points at — and cards that no longer exist.
+
+The orphan case is the instructive one: an entity renamed locally after a push
+leaves the store with an entity that has no card and DeepVista with a card that
+has no entity, and the next push creates the twin. **A rename after a push needs
+the card id carried across** (`record` on the new id) or the old card deleted;
+`fetch` lists both halves so the pair is visible.
+
+Findings from actual runs — counts, which entities, what the product did on a
+given day — belong in the private layer, not here.
 
 It reports four buckets, and only the last two are interesting:
 

--- a/.claude/skills/catchup/scripts/deepvista_cards.py
+++ b/.claude/skills/catchup/scripts/deepvista_cards.py
@@ -19,6 +19,13 @@ and record the returned card id. The model makes the actual tool calls in betwee
 
     plan  ->  [model calls the deepvista MCP tools]  ->  record
 
+Reading back is the exception: once the mcp-remote proxy has cached a sign-in,
+`fetch` spawns it and reads the week's cards headlessly, into a file the
+aggregator's control (and `compare`) can run on. Reads are free and change
+nothing, which is why that half is scripted and the push half is not.
+
+    fetch --week W --out cards.json  ->  [a summary written from the cards]  ->  compare
+
 Skipping matters. The free tier is 100 credits a month, so an entity whose
 content has not changed since its last push must cost nothing: `plan` compares a
 content hash and emits `skip` for anything unchanged.
@@ -143,6 +150,227 @@ def node_runtime():
         return npx, None, (f"npx {nver} is older than the required {MCP_MIN_NPX}+ "
                            f"and cannot run this entry{alt}")
     return npx, major, f"Node v{major} at {node}, npx {nver}"
+
+
+def resolve_npx(explicit=None):
+    """An npx that can run the proxy, or None -- looking past PATH's first hit.
+
+    `node_runtime()` answers "will the entry in .mcp.json start", which is a
+    PATH question because the host app resolves the bare `npx` it names. This
+    answers a different one: "can THIS script start the proxy itself" -- and for
+    that the well-known install locations are fair game, because the path is
+    used here and never written into a repo file. A Homebrew npx 11 sitting
+    behind an npm-6 npx on PATH is exactly the machine this was written on.
+    """
+    cands = [explicit] if explicit else []
+    cands += [shutil.which("npx"), "/opt/homebrew/bin/npx", "/usr/local/bin/npx"]
+    seen = set()
+    for c in cands:
+        if not c or c in seen or not os.path.isfile(c):
+            continue
+        seen.add(c)
+        try:
+            v = subprocess.run([c, "--version"], capture_output=True, text=True,
+                               timeout=20).stdout.strip()
+            if int(v.split(".")[0]) >= MCP_MIN_NPX:
+                return c
+        except (OSError, subprocess.SubprocessError, ValueError, IndexError):
+            continue
+    return None
+
+
+class McpClient:
+    """The smallest MCP client that can read cards: JSON-RPC over the proxy's stdio.
+
+    This exists because "MCP tools are called by the model, not by a script" was
+    true only until the proxy cached a token. Once `mcp-remote` has signed in
+    once, it will start headless for anyone who spawns it -- an agent session or
+    a shell script alike -- and a READ of the week's cards is then a deterministic
+    thing a script can own, the same way `plan` and `record` already are. Writes
+    stay with the model on purpose: they spend credits and change the product,
+    and a script that pushes on its own is a script that pushes twice.
+
+    If the proxy needs a sign-in it prints the authorization URL to stderr and
+    waits. That is surfaced rather than hidden, because the fix is a human in a
+    browser and no amount of retrying substitutes for one.
+    """
+
+    # A session opened right after another proxy shut down can come back
+    # `Session not found` on its first call, or the handshake can stall -- seen
+    # repeatedly on 2026-09-02 whenever two reads ran back to back, and never
+    # when they were minutes apart. The previous proxy's teardown is the likely
+    # racer. Whatever the cause, the recovery is the same: a fresh proxy after a
+    # short pause. So the handshake is attempted a few times, each on a new
+    # process, and the count is reported so a run that needed it stands out.
+    ATTEMPTS = 4
+    BACKOFF = 2.5
+    TOLERATED = ("Session not found",)
+
+    def __init__(self, npx, endpoint=MCP_ENDPOINT, timeout=90):
+        import time
+        self.npx, self.endpoint, self.timeout = npx, endpoint, timeout
+        self.reinits = 0
+        self.attempts = 0
+        self.proc = None
+        last = None
+        for i in range(self.ATTEMPTS):
+            self.attempts += 1
+            if i:
+                self.close()
+                time.sleep(self.BACKOFF * i)
+            self._spawn()
+            ok, last = self._handshake()
+            if ok:
+                return
+        url = self._auth_url()
+        if url:
+            die("DeepVista needs a browser sign-in before this can run headless.\n"
+                f"  Open once, then re-run:\n  {url}\n"
+                "  (mcp-remote caches the token under ~/.mcp-auth after that.)")
+        die(f"could not open a session after {self.ATTEMPTS} attempts; last: {last}")
+
+    def _spawn(self):
+        import threading
+        # Its own process group, so close() can take the proxy down WITH the
+        # node child npx spawns. Terminating npx alone left the proxy running
+        # after the first probes.
+        self.proc = subprocess.Popen(
+            [self.npx, "-y", "mcp-remote", self.endpoint],
+            stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            text=True, bufsize=1, start_new_session=True)
+        self._lines = []          # stdout, JSON-RPC
+        self._stderr = []         # proxy chatter, kept for diagnosis
+        self._lock = threading.Lock()
+        self._next = 1
+        threading.Thread(target=self._pump, args=(self.proc.stdout, self._lines),
+                         daemon=True).start()
+        threading.Thread(target=self._pump, args=(self.proc.stderr, self._stderr),
+                         daemon=True).start()
+
+    def _handshake(self):
+        """initialize + initialized on the current proxy. (ok, error-text)."""
+        r = self._rpc("initialize", {
+            "protocolVersion": "2025-03-26", "capabilities": {},
+            "clientInfo": {"name": "catchup-deepvista-cards", "version": "1"}},
+            tolerate=self.TOLERATED, fatal=False)
+        if r is None or r.get("error"):
+            return False, (json.dumps(r["error"])[:200] if r else "no reply")
+        self.server = (r.get("result") or {}).get("serverInfo") or {}
+        self._notify("notifications/initialized")
+        return True, None
+
+    def _pump(self, stream, sink):
+        for line in stream:
+            with self._lock:
+                sink.append(line)
+
+    def _auth_url(self):
+        for i, line in enumerate(self._stderr):
+            if "Please authorize this client" in line:
+                for nxt in self._stderr[i + 1:i + 4]:
+                    if nxt.strip().startswith("http"):
+                        return nxt.strip()
+        return None
+
+    def _send(self, msg):
+        try:
+            self.proc.stdin.write(json.dumps(msg) + "\n")
+            self.proc.stdin.flush()
+        except (OSError, ValueError) as e:
+            die(f"proxy went away while sending {msg.get('method')}: {e}")
+
+    def _notify(self, method, params=None):
+        self._send({"jsonrpc": "2.0", "method": method, "params": params or {}})
+
+    def _rpc(self, method, params, tolerate=(), fatal=True):
+        """One request, one reply. An error reply dies unless its text contains
+        one of `tolerate`, in which case the raw reply is returned for the
+        caller to recover from. With fatal=False a timeout returns None
+        instead of dying, so a handshake can be retried on a fresh proxy."""
+        import time
+        rid = self._next
+        self._next += 1
+        self._send({"jsonrpc": "2.0", "id": rid, "method": method, "params": params})
+        # A handshake that has not answered in 30s is not going to; the full
+        # timeout is for calls that do real work.
+        end = time.time() + (min(self.timeout, 30) if method == "initialize" else self.timeout)
+        seen = 0
+        while time.time() < end:
+            with self._lock:
+                chunk, seen = self._lines[seen:], len(self._lines)
+            for line in chunk:
+                try:
+                    m = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if m.get("id") == rid:
+                    if "error" in m:
+                        txt = json.dumps(m["error"])
+                        if any(t in txt for t in tolerate):
+                            return m
+                        die(f"{method}: {txt[:400]}")
+                    return m
+            if self.proc.poll() is not None:
+                break
+            time.sleep(0.05)
+        if not fatal:
+            return None
+        url = self._auth_url()
+        tail = "".join(self._stderr[-6:]).strip()
+        if url:
+            die("DeepVista needs a browser sign-in before this can run headless.\n"
+                f"  Open once, then re-run:\n  {url}\n"
+                "  (mcp-remote caches the token under ~/.mcp-auth after that.)")
+        die(f"no reply to {method} within {self.timeout}s"
+            + (f"; proxy said:\n{tail}" if tail else ""))
+
+    def _reinit(self):
+        """The session went away mid-run: a fresh proxy, same retry ladder."""
+        import time
+        self.reinits += 1
+        for i in range(self.ATTEMPTS):
+            self.close()
+            time.sleep(self.BACKOFF * (i + 1))
+            self._spawn()
+            ok, last = self._handshake()
+            if ok:
+                return
+        die(f"session lost mid-run and could not be reopened; last: {last}")
+
+    def call(self, tool, **args):
+        """Call a tool; return its structured result (or its text parsed as JSON)."""
+        r = self._rpc("tools/call", {"name": tool, "arguments": args},
+                      tolerate=self.TOLERATED)
+        if r.get("error"):
+            self._reinit()
+            r = self._rpc("tools/call", {"name": tool, "arguments": args})
+        res = r.get("result") or {}
+        if res.get("isError"):
+            txt = " ".join(c.get("text", "") for c in res.get("content") or [])
+            return {"_error": txt.strip()[:400] or "tool reported an error"}
+        if res.get("structuredContent") is not None:
+            return res["structuredContent"]
+        for c in res.get("content") or []:
+            if c.get("type") == "text":
+                try:
+                    return json.loads(c["text"])
+                except json.JSONDecodeError:
+                    return {"_text": c["text"]}
+        return res
+
+    def close(self):
+        import signal
+        if not self.proc:
+            return
+        try:
+            os.killpg(self.proc.pid, signal.SIGTERM)
+            self.proc.wait(timeout=10)
+        except (OSError, subprocess.SubprocessError):
+            try:
+                os.killpg(self.proc.pid, signal.SIGKILL)
+            except OSError:
+                pass
+        self.proc = None
 
 
 def choose_transport(pref):
@@ -688,6 +916,15 @@ def _mentions(text, entity):
     low = text.lower()
     if (entity.get("title") or "").lower() in low:
         return True
+    # A learning renders as its CLAIM, not its title -- the local summary leads
+    # every "What we learned" bullet with the claim sentence and carries the
+    # title nowhere. Title-only matching scored all four concept rows of the
+    # first control run as "only the DeepVista summary" when the local one had
+    # every one of them, one line each. Match the claim's opening too.
+    for wk in (entity.get("weeks") or {}).values():
+        claim = (wk.get("claim") or "").strip().rstrip(".").lower()
+        if len(claim) > 24 and claim[:60] in low:
+            return True
     parts = [p for p in entity["id"].split("-") if len(p) > 3]
     return bool(parts) and all(p in low for p in parts[:2])
 
@@ -765,6 +1002,185 @@ def cmd_compare(args, repo, cfg, sdir):
          "matter or a shared blind spot.")
 
 
+TRACER = "<!-- catchup-entity: {id} -->"
+
+
+def _tracer_state(body, eid):
+    """intact / escaped / missing -- whether the card still points at its entity.
+
+    `escaped` is a real state, not a parse failure: a links-only upsert on the
+    first live push re-saved bodies through an HTML-escaping pass, so the tracer
+    on those cards reads `&lt;!-- ... --&gt;` and their `&` became `&amp;`. The
+    card is still the right card; its body is no longer byte-for-byte what was
+    sent, and a control that did not distinguish the two would score the
+    escaping damage as a content difference.
+    """
+    if TRACER.format(id=eid) in body:
+        return "intact"
+    if TRACER.format(id=eid).replace("<", "&lt;").replace(">", "&gt;") in body:
+        return "escaped"
+    return "missing"
+
+
+def _unescape(body):
+    return (body.replace("&lt;", "<").replace("&gt;", ">")
+                .replace("&quot;", '"').replace("&#39;", "'").replace("&amp;", "&"))
+
+
+def _body_state(card_body, rendered, tracer):
+    """matches / cosmetic / differs -- how far the card body is from the render.
+
+    The product does not hand a body back byte-for-byte: on the first live push
+    it backslash-escaped `[grade]` markers, inserted blank lines, and (on the
+    links-only pass) HTML-escaped the whole thing. None of that is a content
+    difference, and a control that reported it as one would drown the signal it
+    exists to carry -- an entity whose text moved on after it was pushed. So
+    the comparison is made on a normalised form, and the raw inequality is
+    reported as `cosmetic` rather than hidden.
+    """
+    got = _unescape(card_body) if tracer == "escaped" else card_body
+    if got.strip() == rendered.strip():
+        return "matches"
+    norm = lambda s: re.sub(r"\s+", " ", re.sub(r"\\([\[\]*_`#>~|])", r"\1", s)).strip()
+    return "cosmetic" if norm(got) == norm(rendered) else "differs"
+
+
+def cmd_fetch(args, repo, cfg, sdir):
+    """Read a week's cards BACK from DeepVista, as a file a control can be run on.
+
+    The push is one direction; this is the other. It fetches every card the
+    store says it pushed for the week, browses the repo's tag for cards the store
+    does NOT know about, and writes one JSON file carrying the card bodies plus a
+    fidelity read per card -- whether the tracer survived, and whether the body
+    is what the entity would render today.
+
+    That file is what the aggregator's control is built on: a second summary of
+    the same week, written from the cards alone and diffed against the local one
+    with `compare`. A read costs no credits and changes nothing, which is why
+    this half is scripted and the push half is not.
+    """
+    ents = load_all(sdir)
+    all_ents = list(ents)
+    if args.week:
+        ents = [e for e in ents if args.week in (e.get("weeks") or {})]
+    elif not args.all:
+        die("pass --week YYYY-WNN or --all")
+    if not ents:
+        die(f"no entities recorded for {args.week or 'any week'}")
+
+    dv_cfg = cfg.get("deepvista") or {}
+    if not dv_cfg.get("enabled") and not args.force:
+        die("deepvista.enabled is not true in this repo's config; pass --force to read anyway")
+    titles = category_titles(cfg)
+    repo_label = (cfg.get("repo") or {}).get("label") or os.path.basename(repo)
+
+    npx = resolve_npx(args.npx)
+    if not npx:
+        die(f"no npx {MCP_MIN_NPX}+ found to run the mcp-remote proxy -- `brew install node`, "
+            "or pass --npx /path/to/npx")
+    client = McpClient(npx, timeout=args.timeout)
+    try:
+        # The complete listing under this repo's tag, which is the only way to
+        # see cards the store has forgotten -- a `record` that never ran leaves a
+        # live card behind with no entity pointing at it, and the next push
+        # creates its twin. Empty query = exact listing, per the tool's own docs.
+        listing = client.call("search_context_cards", query="",
+                              tag=f"repo:{repo_label}", limit=100)
+        hits = listing.get("hits") or [] if isinstance(listing, dict) else []
+        listed = {h.get("card_id"): h for h in hits if h.get("card_id")}
+        listing_complete = len(hits) < 100
+
+        known = {(x.get("deepvista") or {}).get("card_id"): x["id"]
+                 for x in all_ents if (x.get("deepvista") or {}).get("card_id")}
+
+        cards, not_found, unpushed = [], [], []
+        for e in sorted(ents, key=lambda x: (x.get("category", ""), x["id"])):
+            dv = e.get("deepvista") or {}
+            cid = dv.get("card_id")
+            if not cid:
+                unpushed.append(e["id"])
+                continue
+            card = client.call("read_context_card", card_id=cid)
+            if not isinstance(card, dict) or card.get("_error") or not card.get("id"):
+                not_found.append({"entity_id": e["id"], "card_id": cid,
+                                  "error": (card or {}).get("_error", "no card returned")})
+                continue
+            body = card.get("description") or ""
+            tracer = _tracer_state(body, e["id"])
+            state = _body_state(body, render_body(e, titles, repo_label), tracer)
+            cards.append({
+                "entity_id": e["id"],
+                "entity_type": e.get("type"),
+                "category": e.get("category"),
+                "card_id": cid,
+                "card_type": card.get("type"),
+                "title": card.get("title"),
+                "status": card.get("status"),
+                "tags": card.get("tags") or [],
+                "created_at": card.get("created_at"),
+                "updated_at": card.get("updated_at"),
+                "synced_at": dv.get("synced_at"),
+                "tracer": tracer,
+                # Two separate questions. `store_current`: has the entity changed
+                # since it was pushed (plan would say `update`)? `body`: is the
+                # card what the entity renders to NOW -- matches, cosmetic, or
+                # differs? `differs` with store_current false is the ordinary
+                # "entity moved on" case; `differs` with store_current TRUE means
+                # the product changed the content, which is the one to look at.
+                "store_current": dv.get("content_hash") == content_hash(e),
+                "body": state,
+                "description": body,
+            })
+
+        orphans = [{"card_id": cid, "card_type": h.get("card_type"), "title": h.get("title")}
+                   for cid, h in listed.items() if cid not in known]
+    finally:
+        client.close()
+
+    out = {
+        "week": args.week,
+        "repo": repo_label,
+        "endpoint": MCP_ENDPOINT,
+        "server": client.server,
+        "session": {"handshake_attempts": client.attempts, "reinits": client.reinits},
+        "fetched_at": utc_now(),
+        "listing": {"tag": f"repo:{repo_label}", "cards": len(listed),
+                    "complete": listing_complete},
+        "counts": {
+            "entities": len(ents),
+            "fetched": len(cards),
+            "unpushed": len(unpushed),
+            "not_found": len(not_found),
+            "orphans": len(orphans),
+            "tracer": dict(sorted(
+                {t: sum(1 for c in cards if c["tracer"] == t) for t in
+                 ("intact", "escaped", "missing")}.items())),
+            "body": dict(sorted(
+                {s: sum(1 for c in cards if c["body"] == s) for s in
+                 ("matches", "cosmetic", "differs")}.items())),
+            "store_current": sum(1 for c in cards if c["store_current"]),
+        },
+        "cards": cards,
+        "unpushed": unpushed,
+        "not_found": not_found,
+        "orphans": orphans,
+    }
+    blob = json.dumps(out, indent=2, ensure_ascii=False) + "\n"
+    if args.out:
+        os.makedirs(os.path.dirname(os.path.abspath(args.out)) or ".", exist_ok=True)
+        with open(args.out, "w") as fh:
+            fh.write(blob)
+        c = out["counts"]
+        print(f"fetched {c['fetched']}/{c['entities']} cards for {repo_label} {args.week or ''} "
+              f"-> {args.out}\n  tracer {c['tracer']} · body vs render "
+              f"{c['body']} · unpushed {c['unpushed']} · not found "
+              f"{c['not_found']} · orphans under tag {c['orphans']}"
+              + ("" if listing_complete else "  (listing hit the 100-card cap; orphans may be undercounted)"),
+              file=sys.stderr)
+    else:
+        sys.stdout.write(blob)
+
+
 def cmd_record(args, repo, cfg, sdir):
     p = entity_path(sdir, args.id)
     if not os.path.isfile(p):
@@ -825,6 +1241,16 @@ def main():
     p.add_argument("--ours", default=None, help="local summary (default: the week's file)")
     p.add_argument("--json", action="store_true")
     p.set_defaults(fn=cmd_compare)
+
+    p = sub.add_parser("fetch", parents=[common],
+                       help="read a week's cards back from DeepVista into a JSON file (headless)")
+    p.add_argument("--week")
+    p.add_argument("--all", action="store_true")
+    p.add_argument("--out", default=None, help="write here instead of stdout")
+    p.add_argument("--npx", default=None, help="npx to run the mcp-remote proxy with")
+    p.add_argument("--timeout", type=int, default=90, help="seconds to wait per call")
+    p.add_argument("--force", action="store_true", help="read even if deepvista.enabled is false")
+    p.set_defaults(fn=cmd_fetch)
 
     p = sub.add_parser("record", parents=[common], help="write back the card id after an MCP call")
     p.add_argument("--id", required=True)

--- a/.claude/skills/rollup/SKILL.md
+++ b/.claude/skills/rollup/SKILL.md
@@ -138,11 +138,16 @@ runs *that repo's* deployed `deepvista_cards.py fetch` and, once a summary
 exists, its `compare`, and files the results beside the sources they are the
 control for:
 
-| File under `rollups/<W>/<repo>/` | Produced by | What it is |
+Machine files stay with the snapshot; everything a person reads goes in
+`drafts/`, beside the manual draft, so the whole DeepVista version of a week
+is in one place:
+
+| File | Produced by | What it is |
 |---|---|---|
-| `deepvista-cards.json` | `fetch` (headless) | What DeepVista holds for the week: card bodies plus a fidelity read per card — tracer intact/escaped/missing, body matches/cosmetic/differs — and the repo's unpushed entities and orphan cards |
-| `deepvista-summary.md` | **you**, by hand | The week written from the cards **alone**, in the catchup's shape. Write it before opening the local summary or the store, or it is not a control |
-| `deepvista-compare.json` | `compare` | Coverage diff: covered by both, only local, only DeepVista, neither |
+| `rollups/<W>/<repo>/deepvista-cards.json` | `fetch` (headless) | What DeepVista holds for the week: card bodies plus a fidelity read per card — tracer intact/escaped/missing, body matches/cosmetic/differs — and the repo's unpushed entities and orphan cards |
+| `drafts/<W>.deepvista.<repo>.md` | **you**, by hand | That repo's week written from the cards **alone**, in the catchup's shape. Write it before opening the local summary or the store, or it is not a control. (The rollup also accepts it at `rollups/<W>/<repo>/deepvista-summary.md`, for a repo running the read on its own) |
+| `rollups/<W>/<repo>/deepvista-compare.json` | `compare` | Coverage diff: covered by both, only local, only DeepVista, neither |
+| `drafts/<W>.deepvista-draft1.md` | **you**, by hand | The sum-up: the weekly's draft 1 written from the cards alone, in the same three-part shape as the manual `drafts/<W>.draft1.md` — raw material, scrub delta, public candidate with the human blocks left as prompts — and a **delta against the manual draft** at the end. This is what "the DeepVista version" means to a reader of the weekly; the per-repo files are its inputs |
 
 So the command runs **twice**: once to fetch (it reports `no deepvista-summary.md
 yet`), then again after the summaries are written, to compare. The cards file
@@ -164,6 +169,15 @@ is reused on the second run — `--refetch` to pull again.
 
 The control's own findings go in the rollup under `## Control: DeepVista`, and
 the per-repo fixes go back to the repo that owns the entity.
+
+**Then write the weekly's draft 1 from the cards**, as `drafts/<W>.deepvista-draft1.md`
+in the private repo, following the fnr skill's draft-1 rules exactly — same
+template, human blocks left as prompts, never a finished learning in his voice —
+and close it with the delta against the manual draft: what the cards
+reconstructed, what they got wrong (a card is only as current as the last
+push), and what no card could carry (the personal lane, the calendar, the
+intake queue, him). The two drafts side by side are the control's real output;
+the compare buckets are how you got there.
 
 ## Write from the rollup, never from the session
 

--- a/.claude/skills/rollup/SKILL.md
+++ b/.claude/skills/rollup/SKILL.md
@@ -113,6 +113,58 @@ The table is the orientation pass; the JSON carries every entity body.
 cover N of M repos. A total presented as complete when a repo is missing is the
 one error this layer can make that nobody downstream can detect.
 
+**Snapshot the sources**, every run — `--snapshot rollups` files every week
+record, summary and entity set the numbers came from under `rollups/<W>/<repo>/`,
+with hashes. A snapshot that already exists is **kept**: a source that has
+moved on since capture is reported as `drift` and left as captured, because
+the rollup was built from the captured copy and a silent replacement rewrites
+its provenance. `--recapture` is the deliberate act of taking a new one.
+
+## Step 2b: The control — DeepVista
+
+The skills here produce the record. DeepVista is the **control**: each syncing
+repo has pushed its entities there as cards, and reading those cards back
+gives a second reader of the same evidence. The aggregator runs that read for
+every repo in one pass, because the question it answers — *what did each
+summary leave out, and did both leave out the same thing* — is a cross-repo
+question.
+
+```bash
+uv run .claude/skills/rollup/scripts/rollup.py 2026-W35 --snapshot rollups --control deepvista --table
+```
+
+Nothing is re-derived: for each repo whose config has `deepvista.enabled`, this
+runs *that repo's* deployed `deepvista_cards.py fetch` and, once a summary
+exists, its `compare`, and files the results beside the sources they are the
+control for:
+
+| File under `rollups/<W>/<repo>/` | Produced by | What it is |
+|---|---|---|
+| `deepvista-cards.json` | `fetch` (headless) | What DeepVista holds for the week: card bodies plus a fidelity read per card — tracer intact/escaped/missing, body matches/cosmetic/differs — and the repo's unpushed entities and orphan cards |
+| `deepvista-summary.md` | **you**, by hand | The week written from the cards **alone**, in the catchup's shape. Write it before opening the local summary or the store, or it is not a control |
+| `deepvista-compare.json` | `compare` | Coverage diff: covered by both, only local, only DeepVista, neither |
+
+So the command runs **twice**: once to fetch (it reports `no deepvista-summary.md
+yet`), then again after the summaries are written, to compare. The cards file
+is reused on the second run — `--refetch` to pull again.
+
+**Read the control in this order:**
+
+1. **The fidelity row first.** Unpushed entities, orphan cards and `differs`
+   bodies are defects in the *sync*, and they bound what the summary comparison
+   can mean — a card that was never pushed cannot be covered by the DeepVista
+   summary, and scoring that as the local writer's win is wrong.
+2. **`covered_by_neither`** — in the store, in no summary. Two writers passed
+   over it independently: agreement that it does not matter, or a shared blind
+   spot. Say which.
+3. **`only_deepvista`** — the local summary left it out. Judgment or omission?
+   Pull the better version *by entity* into the local summary in the source
+   repo; never edit the summary here.
+4. `only_ours` is usually the push not carrying something. Rarely interesting.
+
+The control's own findings go in the rollup under `## Control: DeepVista`, and
+the per-repo fixes go back to the repo that owns the entity.
+
 ## Write from the rollup, never from the session
 
 **The single most likely way to get this wrong: describing the work of the
@@ -184,6 +236,13 @@ directory if absent.
 ## Carried over
 - <what is continuing, with its span>
 
+## Control: DeepVista
+| Repo | Cards | Tracer | Body | Both | Only local | Only DV | Neither |
+(from the control table; then what the buckets mean, read across repos)
+- <sync defects found: unpushed, orphans, differs — and the fix, per repo>
+- <what both summaries left out, and whether that is agreement or a blind spot>
+- <what the card-only summary carried that the local one dropped>
+
 ## For the weekly
 - <what a reader outside would find interesting — the candidates, not the copy>
 ```
@@ -197,6 +256,8 @@ public/private boundary is the whole point of keeping the layers apart.
 State the week, repos reporting out of registered, combined stats (making clear
 which are publishable), the cross-repo threads, and anything that looked
 under- or over-extracted. If any repo is missing a week record, lead with that.
+If the control ran, give its one-line verdict per repo — sync defects first,
+then the coverage buckets — and name what goes back to which repo.
 
 ---
 
@@ -212,3 +273,9 @@ under- or over-extracted. If any repo is missing a week record, lead with that.
   catchup and re-run — don't compute a second version here.
 - **Restating the per-repo summaries.** If a paragraph would be equally true in
   a single repo's catchup, it does not belong in the rollup.
+- **Writing the control summary with the local one open.** A card-only summary
+  that has seen the local file is a copy with the names changed, and the
+  coverage diff then measures nothing.
+- **Reading the coverage diff before the fidelity row.** An entity that was
+  never pushed is absent from the DeepVista summary by construction, not by
+  judgment.

--- a/.claude/skills/rollup/scripts/rollup.py
+++ b/.claude/skills/rollup/scripts/rollup.py
@@ -538,13 +538,22 @@ def control_deepvista(d, out_dir, refetch=False):
         entry["orphans"] = [o.get("title") for o in cards.get("orphans") or []]
         entry["unpushed"] = cards.get("unpushed") or []
 
-        summary = os.path.join(rd, CONTROL_SUMMARY)
-        if not os.path.isfile(summary):
+        # The card-only summary is a draft a person writes, so it lives with the
+        # drafts -- `drafts/<W>.deepvista.<repo>.md` in the private repo, beside
+        # the manual draft 1 and the card-only weekly. The snapshot path is the
+        # fallback for a repo running the read on its own.
+        candidates = [
+            os.path.join(PRIVATE_DIR, "drafts", f"{d['week']}.deepvista.{r['name']}.md"),
+            os.path.join(rd, CONTROL_SUMMARY),
+        ]
+        summary = next((p for p in candidates if os.path.isfile(p)), None)
+        if not summary:
             entry["compare"] = None
-            entry["next"] = (f"write {CONTROL_SUMMARY} from {CONTROL_CARDS} alone, "
-                             "then re-run with --control deepvista")
+            entry["next"] = (f"write {os.path.relpath(candidates[0], PRIVATE_DIR)} from "
+                             f"{CONTROL_CARDS} alone, then re-run with --control deepvista")
             results.append(entry)
             continue
+        entry["summary"] = os.path.relpath(summary, PRIVATE_DIR)
         p = subprocess.run(_runner() + [script, "compare", d["week"], "--repo", r["path"],
                                         "--against", summary, "--json"],
                            capture_output=True, text=True, timeout=300)
@@ -608,7 +617,7 @@ def render_control(results):
             note = ""
         else:
             cols = f"{'':>5}{'':>6}{'':>4}{'':>5}"
-            note = f"no {CONTROL_SUMMARY} yet"
+            note = "no card-only summary yet"
         extra = []
         if c.get("unpushed"):
             extra.append(f"{c['unpushed']} unpushed")

--- a/.claude/skills/rollup/scripts/rollup.py
+++ b/.claude/skills/rollup/scripts/rollup.py
@@ -361,7 +361,7 @@ def render_table(d):
     return "\n".join(out)
 
 
-def snapshot(d, out_dir):
+def snapshot(d, out_dir, recapture=False):
     """Copy everything the rollup read into one directory beside its output.
 
     Provenance: a rollup is a claim about several repos on one date, and the
@@ -369,9 +369,46 @@ def snapshot(d, out_dir):
     come from" is answerable only by re-running against a tree that has since
     changed -- which is not an answer. Weeks accumulate here, so later rollups
     can read further back than the current state of anyone's working tree.
+
+    A snapshot that already exists is KEPT, not overwritten. The first re-run
+    after the entity store had moved on -- a sync had stamped card ids onto
+    every entity and one entity had been renamed -- silently replaced the
+    entities the rollup was actually built from with a later set, one short.
+    So a file whose source has changed since capture is left as it was and
+    reported as `drift` with both hashes, and `--recapture` is the deliberate
+    act of taking a new one. The manifest keeps its original `captured` stamp
+    for the same reason.
     """
     os.makedirs(out_dir, exist_ok=True)
-    manifest = {"week": d["week"], "captured": d["generated"],
+    mpath = os.path.join(out_dir, "sources.json")
+    prior = None
+    if os.path.isfile(mpath) and not recapture:
+        try:
+            with open(mpath) as fh:
+                prior = json.load(fh)
+        except (OSError, json.JSONDecodeError):
+            prior = None
+    prior_files = {s["name"]: s.get("files") or {} for s in (prior or {}).get("sources", [])
+                   if isinstance(s, dict) and s.get("name")}
+
+    def keep_or_write(rd, fname, body, meta, name):
+        """Write a source file unless a captured one exists and the source moved."""
+        p = os.path.join(rd, fname)
+        h = hashlib.sha256(body.encode()).hexdigest()[:16]
+        was = (prior_files.get(name) or {}).get(fname)
+        if was and os.path.isfile(p) and was.get("sha256") != h:
+            print(f"rollup: {name}/{fname}: source changed since capture "
+                  f"({was['sha256']} -> {h}); keeping the captured copy. "
+                  f"--recapture to replace it.", file=sys.stderr)
+            return dict(was, drift={"now": h})
+        if not (was and os.path.isfile(p) and was.get("sha256") == h):
+            with open(p, "w") as fh:
+                fh.write(body)
+        return dict(meta, sha256=h)
+
+    manifest = {"week": d["week"],
+                "captured": (prior or {}).get("captured") or d["generated"],
+                "checked": d["generated"],
                 "repos_reporting": d["repos_reporting"],
                 "repos_registered": d["repos_registered"],
                 "totals": d["totals"], "public_totals": d["public_totals"],
@@ -387,38 +424,202 @@ def snapshot(d, out_dir):
         try:
             with open(r["record_path"]) as fh:
                 rec = fh.read()
-            with open(os.path.join(rd, "week.json"), "w") as fh:
-                fh.write(rec)
-            src_files["week.json"] = {"from": r["record_path"],
-                                      "sha256": hashlib.sha256(rec.encode()).hexdigest()[:16]}
+            src_files["week.json"] = keep_or_write(rd, "week.json", rec,
+                                                   {"from": r["record_path"]}, r["name"])
         except OSError:
             pass
         if r.get("summary_path"):
             try:
                 with open(r["summary_path"]) as fh:
                     body = fh.read()
-                with open(os.path.join(rd, "summary.md"), "w") as fh:
-                    fh.write(body)
-                src_files["summary.md"] = {"from": r["summary_path"],
-                                           "sha256": hashlib.sha256(body.encode()).hexdigest()[:16]}
+                src_files["summary.md"] = keep_or_write(rd, "summary.md", body,
+                                                        {"from": r["summary_path"]}, r["name"])
             except OSError:
                 pass
         ents = r.get("entities") or []
         if ents:
-            blob = json.dumps(ents, indent=2, sort_keys=True)
-            with open(os.path.join(rd, "entities.json"), "w") as fh:
-                fh.write(blob + "\n")
-            src_files["entities.json"] = {"count": len(ents),
-                                          "sha256": hashlib.sha256(blob.encode()).hexdigest()[:16]}
+            blob = json.dumps(ents, indent=2, sort_keys=True) + "\n"
+            src_files["entities.json"] = keep_or_write(rd, "entities.json", blob,
+                                                       {"count": len(ents)}, r["name"])
+        if r.get("missing_entity_files"):
+            src_files["missing_entity_files"] = list(r["missing_entity_files"])
         manifest["sources"].append({
             "name": r["name"], "captured": True, "lane": r.get("lane"),
             "disclosure": r.get("disclosure"), "public_stats": r.get("public_stats"),
             "path": r["path"], "files": src_files,
         })
-    with open(os.path.join(out_dir, "sources.json"), "w") as fh:
+    if prior and prior.get("control"):
+        manifest["control"] = prior["control"]
+    with open(mpath, "w") as fh:
         json.dump(manifest, fh, indent=2)
         fh.write("\n")
     return manifest
+
+
+CONTROL_CARDS = "deepvista-cards.json"
+CONTROL_SUMMARY = "deepvista-summary.md"
+CONTROL_COMPARE = "deepvista-compare.json"
+
+
+def _runner():
+    """`uv run` where it exists -- the convention every script here follows --
+    else the interpreter running this one. Both resolve a stdlib-only script."""
+    import shutil
+    uv = shutil.which("uv")
+    return [uv, "run"] if uv else [sys.executable]
+
+
+def control_deepvista(d, out_dir, refetch=False):
+    """Run the DeepVista control for every reporting repo that pushes to it.
+
+    The catchup skill pushes each repo's entities to DeepVista as cards; this
+    reads them BACK, per repo, and diffs a summary written from the cards
+    against the summary written from the store. Two readers of the same
+    evidence, and the interesting output is where they disagree.
+
+    Nothing here is re-derived. The fetch and the compare are the source repo's
+    own catchup script, run in that repo -- the aggregator reads products, it
+    does not produce them -- and the files land in the snapshot beside the
+    local sources they are the control for:
+
+        <snapshot>/<W>/<repo>/deepvista-cards.json     what DeepVista holds (fetched)
+        <snapshot>/<W>/<repo>/deepvista-summary.md     written from the cards ALONE (by hand)
+        <snapshot>/<W>/<repo>/deepvista-compare.json   coverage diff (once the summary exists)
+
+    So this runs twice by design: once to fetch, once more after the summary
+    has been written, to compare. The cards file is reused on the second run
+    unless --refetch says otherwise -- a read is free, but a control whose
+    evidence silently changed between the two runs is not a control.
+    """
+    results = []
+    for r in d["repos"]:
+        if not r.get("has_record"):
+            continue
+        entry = {"name": r["name"], "enabled": False}
+        cfg_path = os.path.join(r["path"], ".claude", "catchup.config.json")
+        try:
+            with open(cfg_path) as fh:
+                dv = (json.load(fh).get("deepvista") or {})
+        except (OSError, json.JSONDecodeError):
+            dv = {}
+        entry["enabled"] = bool(dv.get("enabled"))
+        if not entry["enabled"]:
+            results.append(entry)
+            continue
+
+        script = os.path.join(r["path"], ".claude", "skills", "catchup", "scripts",
+                              "deepvista_cards.py")
+        if not os.path.isfile(script):
+            entry["error"] = "no catchup skill deployed in this repo -- deploy it, then re-run"
+            results.append(entry)
+            continue
+        rd = os.path.join(out_dir, r["name"])
+        os.makedirs(rd, exist_ok=True)
+        cards_path = os.path.join(rd, CONTROL_CARDS)
+
+        if refetch or not os.path.isfile(cards_path):
+            p = subprocess.run(_runner() + [script, "fetch", "--repo", r["path"],
+                                            "--week", d["week"], "--out", cards_path],
+                               capture_output=True, text=True, timeout=900)
+            if p.returncode != 0:
+                entry["error"] = (p.stderr or p.stdout).strip()[-600:]
+                results.append(entry)
+                continue
+            entry["fetched"] = True
+        try:
+            with open(cards_path) as fh:
+                cards = json.load(fh)
+        except (OSError, json.JSONDecodeError) as e:
+            entry["error"] = f"unreadable {CONTROL_CARDS}: {e}"
+            results.append(entry)
+            continue
+        entry["cards"] = cards.get("counts") or {}
+        entry["fetched_at"] = cards.get("fetched_at")
+        entry["orphans"] = [o.get("title") for o in cards.get("orphans") or []]
+        entry["unpushed"] = cards.get("unpushed") or []
+
+        summary = os.path.join(rd, CONTROL_SUMMARY)
+        if not os.path.isfile(summary):
+            entry["compare"] = None
+            entry["next"] = (f"write {CONTROL_SUMMARY} from {CONTROL_CARDS} alone, "
+                             "then re-run with --control deepvista")
+            results.append(entry)
+            continue
+        p = subprocess.run(_runner() + [script, "compare", d["week"], "--repo", r["path"],
+                                        "--against", summary, "--json"],
+                           capture_output=True, text=True, timeout=300)
+        if p.returncode != 0:
+            entry["error"] = f"compare failed: {(p.stderr or p.stdout).strip()[-600:]}"
+            results.append(entry)
+            continue
+        try:
+            cmp_ = json.loads(p.stdout)
+        except json.JSONDecodeError:
+            entry["error"] = "compare returned no JSON"
+            results.append(entry)
+            continue
+        with open(os.path.join(rd, CONTROL_COMPARE), "w") as fh:
+            json.dump(cmp_, fh, indent=2)
+            fh.write("\n")
+        entry["compare"] = {k: len(v) for k, v in cmp_.items() if isinstance(v, list)}
+        entry["compare"]["words"] = cmp_.get("words")
+        entry["only_deepvista"] = cmp_.get("only_deepvista") or []
+        entry["covered_by_neither"] = cmp_.get("covered_by_neither") or []
+        results.append(entry)
+
+    # Into the manifest, beside the sources it is the control FOR.
+    mpath = os.path.join(out_dir, "sources.json")
+    try:
+        with open(mpath) as fh:
+            manifest = json.load(fh)
+    except (OSError, json.JSONDecodeError):
+        manifest = {"week": d["week"]}
+    manifest["control"] = {"deepvista": {
+        "run": dt.datetime.now().isoformat(timespec="seconds"),
+        "files": [CONTROL_CARDS, CONTROL_SUMMARY, CONTROL_COMPARE],
+        "repos": results,
+    }}
+    with open(mpath, "w") as fh:
+        json.dump(manifest, fh, indent=2)
+        fh.write("\n")
+    return results
+
+
+def render_control(results):
+    out = ["  == control: DeepVista ==",
+           f"  {'repo':<16}{'cards':>6}  {'tracer i/e/m':<14}{'body m/c/d':>12}  "
+           f"{'both':>5}{'local':>6}{'dv':>4}{'none':>5}  note"]
+    for e in results:
+        if not e.get("enabled"):
+            out.append(f"  {str(e['name']):<16}{'':>6}  {'':<14}{'':>12}  {'':>5}{'':>6}{'':>4}{'':>5}  sync off")
+            continue
+        if e.get("error"):
+            out.append(f"  {str(e['name']):<16}  ERROR {e['error'].splitlines()[-1][:80]}")
+            continue
+        c = e.get("cards") or {}
+        tr = c.get("tracer") or {}
+        trs = f"{tr.get('intact', 0)}/{tr.get('escaped', 0)}/{tr.get('missing', 0)}"
+        bd = c.get("body") or {}
+        bds = f"{bd.get('matches', 0)}/{bd.get('cosmetic', 0)}/{bd.get('differs', 0)}"
+        cmp_ = e.get("compare")
+        if cmp_:
+            cols = (f"{cmp_.get('covered_by_both', 0):>5}{cmp_.get('only_ours', 0):>6}"
+                    f"{cmp_.get('only_deepvista', 0):>4}{cmp_.get('covered_by_neither', 0):>5}")
+            note = ""
+        else:
+            cols = f"{'':>5}{'':>6}{'':>4}{'':>5}"
+            note = f"no {CONTROL_SUMMARY} yet"
+        extra = []
+        if c.get("unpushed"):
+            extra.append(f"{c['unpushed']} unpushed")
+        if c.get("orphans"):
+            extra.append(f"{c['orphans']} orphan cards under tag")
+        if c.get("not_found"):
+            extra.append(f"{c['not_found']} not found")
+        out.append(f"  {str(e['name']):<16}{c.get('fetched', 0):>6}  {trs:<14}"
+                   f"{bds:>12}  {cols}  "
+                   + "; ".join([x for x in [note] if x] + extra))
+    return "\n".join(out)
 
 
 def main():
@@ -433,7 +634,17 @@ def main():
     ap.add_argument("--snapshot", default=None,
                     help="copy every source read into this directory, with hashes")
     ap.add_argument("--today", default=None, help="override today's date (testing)")
+    ap.add_argument("--control", choices=["deepvista"], default=None,
+                    help="run a control against the snapshot: fetch each repo's cards back "
+                         "from DeepVista, and compare once its deepvista-summary.md exists")
+    ap.add_argument("--refetch", action="store_true",
+                    help="with --control: fetch again even if the cards file exists")
+    ap.add_argument("--recapture", action="store_true",
+                    help="with --snapshot: replace captured sources whose repo has moved on "
+                         "(default keeps them and reports drift)")
     args = ap.parse_args()
+    if args.control and not args.snapshot:
+        die("--control needs --snapshot: the control's files live beside the sources")
 
     today = dt.date.today()
     if args.today:
@@ -459,13 +670,19 @@ def main():
 
     if args.snapshot:
         for d in results:
-            m = snapshot(d, os.path.join(args.snapshot, d["week"]))
+            m = snapshot(d, os.path.join(args.snapshot, d["week"]), recapture=args.recapture)
             print(f"snapshot: {os.path.join(args.snapshot, d['week'])} "
                   f"({sum(1 for s in m['sources'] if s['captured'])} sources captured)",
                   file=sys.stderr)
+            if args.control == "deepvista":
+                d["control"] = {"deepvista": control_deepvista(
+                    d, os.path.join(args.snapshot, d["week"]), refetch=args.refetch)}
 
     if args.table:
         print("\n\n".join(render_table(d) for d in results))
+        for d in results:
+            if d.get("control"):
+                print("\n" + render_control(d["control"]["deepvista"]))
     else:
         print(json.dumps(results[0] if len(results) == 1 else results, indent=2))
 

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "deepvista": {
+      "type": "http",
+      "url": "https://api.deepvista.ai/mcp"
+    }
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,7 @@ reads. Edit canon, never a copy.
 | Skill | What it does |
 |---|---|
 | `catchup` | Per-repo weekly: extract entities from a week, then summarize from them. **Source of truth** — deployed into other repos with its `deploy.py`, so edit it here and redeploy |
-| `rollup` | Cross-repo summary-of-summaries. Output is private by construction |
+| `rollup` | Cross-repo summary-of-summaries, with DeepVista as the control: reads each syncing repo's cards back and diffs coverage against the local summaries. Output is private by construction |
 | `fnr` | The public weekly, written under the scrub policy |
 
 When the human names a skill, **invoke it through its front door** rather than

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ directly.
 | **fnr/** | |
 | `fnr/README.md` | What Field Notes & Reflections is, the F&R pun, and the two-layer public/private model |
 | `fnr/<YYYY-WNN>.md` | One public weekly per ISO week, published Mondays about the week that just closed |
-| `fnr/.private/` | **A separate private repo** — [about-me-private](https://github.com/batmany13/about-me-private) — cloned into this gitignored path. Holds `repos.json` (which repos the weekly reads), `scrub_policy.md` (what may be published), and the unscrubbed drafts. Never commit its contents here, never quote it in public files |
+| `fnr/.private/` | **A separate private repo** — [about-me-private](https://github.com/batmany13/about-me-private) — cloned into this gitignored path. Holds `repos.json` (which repos the weekly reads), `scrub_policy.md` (what may be published), the unscrubbed drafts, and `rollups/` — the cross-repo rollup per week with its snapshotted sources and the DeepVista control files. Never commit its contents here, never quote it in public files |
 | **.claude/skills/** | |
 | `.claude/skills/catchup/` | **Source of truth** for the repo-agnostic `catchup` skill, deployed into other repos with its `deploy.py`. Two passes: extract entities from a week, then summarize from them. Nothing repo-specific lives in it — that goes in each repo's `.claude/catchup.config.json` |
 | `.claude/skills/rollup/` | The summary-of-summaries: reads every registered repo's week records and entities and merges them into one cross-repo view. Private output only |
@@ -142,8 +142,18 @@ start disagreeing.
 | Layer | Skill | Reads | Writes |
 |---|---|---|---|
 | Per repo | `catchup` | that repo's git log + merged PRs | `<output.dir>/entities/*.json`, `weeks/<W>.json`, `<W>.md` — **in that repo**, top level by default |
-| Across repos | `rollup` | each repo's week records + entities | `fnr/.private/rollups/<W>.md` — **private** |
+| Across repos | `rollup` | each repo's week records + entities | `fnr/.private/rollups/<W>.md`, with the sources snapshotted under `rollups/<W>/<repo>/` — **private** |
+| Control | `rollup --control deepvista` | each syncing repo's entities, read **back** from DeepVista as cards | `rollups/<W>/<repo>/deepvista-{cards.json,summary.md,compare.json}` — **private** |
 | Public | `fnr` | the rollup, under the scrub policy | `fnr/<W>.md` — public |
+
+**The aggregator uses both: the skills here are the record, DeepVista is the
+control.** Each syncing repo pushes its entities to DeepVista as context cards
+(catchup Step 5); the rollup reads them back headlessly, has a second summary
+written from the cards alone, and diffs coverage against the local one. What
+both leave out is a shared blind spot; what only the cards carry is an
+omission to pull back into the source repo. It is also the fidelity check on
+the push — unpushed entities, orphan cards, bodies that drifted — which is
+where the first run found most of its findings.
 
 `catchup` is **deployed** into other repos, not run from here:
 
@@ -178,6 +188,7 @@ Use the **fnr** skill (`.claude/skills/fnr/SKILL.md`) or `/fnr`. Don't hand-writ
 1. Read `fnr/.private/repos.json` and `fnr/.private/scrub_policy.md`, and check that repo for uncommitted or unpushed work first (a nested repo in an ignored path is invisible to `git status` here)
 2. Run `.claude/skills/fnr/scripts/pull_week.py <YYYY-WNN>` for commits + attended events
 3. Write the **unscrubbed** catchup into each source repo's `<output.dir>/<week>.md` (`catchup/` by default)
+3b. Roll up across repos **from the private repo** with the DeepVista control (`rollup.py <week> --snapshot rollups --control deepvista`), write each repo's card-only summary, run it again to compare, and read `## Control: DeepVista` before drafting
 4. Derive the **scrubbed** public file at `fnr/<YYYY-WNN>.md` from those catchups
 5. Report the scrub delta — what was held back, by category
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,7 +143,7 @@ start disagreeing.
 |---|---|---|---|
 | Per repo | `catchup` | that repo's git log + merged PRs | `<output.dir>/entities/*.json`, `weeks/<W>.json`, `<W>.md` — **in that repo**, top level by default |
 | Across repos | `rollup` | each repo's week records + entities | `fnr/.private/rollups/<W>.md`, with the sources snapshotted under `rollups/<W>/<repo>/` — **private** |
-| Control | `rollup --control deepvista` | each syncing repo's entities, read **back** from DeepVista as cards | `rollups/<W>/<repo>/deepvista-{cards.json,summary.md,compare.json}` — **private** |
+| Control | `rollup --control deepvista` | each syncing repo's entities, read **back** from DeepVista as cards | `rollups/<W>/<repo>/deepvista-{cards,compare}.json`, and the readable output in `drafts/<W>.deepvista.<repo>.md` + `drafts/<W>.deepvista-draft1.md` — **private** |
 | Public | `fnr` | the rollup, under the scrub policy | `fnr/<W>.md` — public |
 
 **The aggregator uses both: the skills here are the record, DeepVista is the
@@ -188,7 +188,7 @@ Use the **fnr** skill (`.claude/skills/fnr/SKILL.md`) or `/fnr`. Don't hand-writ
 1. Read `fnr/.private/repos.json` and `fnr/.private/scrub_policy.md`, and check that repo for uncommitted or unpushed work first (a nested repo in an ignored path is invisible to `git status` here)
 2. Run `.claude/skills/fnr/scripts/pull_week.py <YYYY-WNN>` for commits + attended events
 3. Write the **unscrubbed** catchup into each source repo's `<output.dir>/<week>.md` (`catchup/` by default)
-3b. Roll up across repos **from the private repo** with the DeepVista control (`rollup.py <week> --snapshot rollups --control deepvista`), write each repo's card-only summary, run it again to compare, and read `## Control: DeepVista` before drafting
+3b. Roll up across repos **from the private repo** with the DeepVista control (`rollup.py <week> --snapshot rollups --control deepvista`), write each repo's card-only summary as `drafts/<week>.deepvista.<repo>.md`, run it again to compare, then write the sum-up — the weekly's draft 1 from the cards alone — as `drafts/<week>.deepvista-draft1.md`, with the delta against the manual draft at its end. Everything a person reads from DeepVista lives in `drafts/`
 4. Derive the **scrubbed** public file at `fnr/<YYYY-WNN>.md` from those catchups
 5. Report the scrub delta — what was held back, by category
 


### PR DESCRIPTION
## What

The catchup skill pushed entities to DeepVista as cards; nothing read them back. This adds the read, and makes the aggregator use both: **the skills here are the record, DeepVista is the control.**

### catchup
- **`deepvista_cards.py fetch`** — reads a week's cards headlessly through the `mcp-remote` proxy's cached sign-in, into one JSON file with a fidelity read per card (tracer intact / escaped / missing; body matches / cosmetic / differs) plus the repo's unpushed entities and orphan cards under its tag. The client resolves an `npx` that can run the proxy past PATH's first hit, respawns with backoff when a session goes missing, and kills its whole process group on close.
- **`compare`** now matches a learning's *claim* as well as its title — the local summary renders learnings as claim sentences, and title-only matching scored every concept row as missing on the first run.
- Step 5b and `reference/deepvista.md` describe the read and the states. Run findings (counts, names, what happened on the day) stay in the private layer.

### rollup
- **`--control deepvista`** — for each repo whose config syncs, runs *that repo's* deployed `fetch` and, once its card-only summary exists, its `compare`; files both beside the snapshotted sources; prints a control table with `--table`; records the control in `sources.json`. Runs twice by design: fetch, write the summary blind, compare.
- **Snapshots are kept, not overwritten.** A source that moved on since capture is reported as `drift` with both hashes; `--recapture` replaces it deliberately. (The first re-run silently replaced the entity set the W35 rollup was built from with a later one, one entity short.)

### repo
- `.mcp.json` registers the DeepVista server here — `http` form, name + URL, no credentials — written by the skill's own `install-mcp`.
- `CLAUDE.md` / `AGENTS.md`: the control as a fourth layer, and the weekly's step 3b.

## Verified
- `fetch` and `compare` ran end to end on 2026-W35 for both syncing repos through the rollup; the results and the W35 control section are in the private repo.
- Skill copies redeployed and `--check` clean in every target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
