### PR TITLE
fixed up catch up syncs across repos

### DIFF
--- a/.claude/skills/catchup/SKILL.md
+++ b/.claude/skills/catchup/SKILL.md
@@ -567,7 +567,7 @@ week is a bullet that failed.
 ## Step 5 (optional): Sync entities to DeepVista
 
 Only when config sets `deepvista.enabled: true`. See
-[`reference/deepvista.md`](reference/deepvista.md) for the full prototype —
+[`reference/deepvista.md`](reference/deepvista.md) for the full runbook —
 endpoint, auth, and the one gotcha that makes cards invisible if you miss it.
 
 **Register the server from the skill, not by hand.** The requirement travels
@@ -692,15 +692,27 @@ the scrubbing happens downstream, never in this file.
 
 ## Keeping the copies honest
 
-This skill is edited in one repo and pointed at from the others. When a copy
-does exist, a fix found in the copy has to travel back to canon — never
-hand-transcribed between them, because the two then differ in ways nobody
-diffed.
+This skill is edited in one repo — the source of truth — and **copied** into
+each repo that runs it by `scripts/deploy.py`, which ships only in the source
+and is never part of a copy. A fix found in a copy travels back with
+`--pull-back`, never by hand, because two hand-transcribed files differ in ways
+nobody diffed.
 
-> **Note:** earlier versions of this document described a `scripts/deploy.py`
-> with `--check` / `--pull-back` / `--check-all`. **That script is not part of
-> this skill.** If a repo has one, it is that repo's own tooling; if you need the
-> behaviour, write it there rather than assuming it ships here.
+```bash
+uv run scripts/deploy.py <repo> --branch <name>   # source -> a worktree of <repo>, on a branch
+uv run scripts/deploy.py <repo> --check           # drifted? exit 1 if so
+uv run scripts/deploy.py <repo> --pull-back       # copy -> source, then review the diff
+```
+
+**A deploy lands on a branch, never in a main checkout.** The script writes
+files and nothing else — no commit — so whatever it leaves behind is the
+caller's to commit and put on a pull request. Written into a checkout on its
+default branch, that becomes uncommitted cruft that a later session has to
+rescue, which is exactly what happened across three repos before the script
+started refusing. `--branch` creates the worktree for you; without it, point
+the script at a worktree you made. It also leaves a `.deployed.json` manifest
+in the copy — commit it, because it is how the next deploy tells a copy that is
+merely *different* from one that is *ahead*.
 
 ## Running under another agent runtime
 

--- a/.claude/skills/catchup/reference/config.md
+++ b/.claude/skills/catchup/reference/config.md
@@ -91,7 +91,7 @@ section is actually felt in:
 
 ```json
 "sections": {
-  "themes":    "500-800",           
+  "themes":    "500-800",
   "meetings":  { "bullets": "24-40" },
   "learnings": "500-800",
   "other":     "50-150"

--- a/.claude/skills/catchup/reference/deepvista.md
+++ b/.claude/skills/catchup/reference/deepvista.md
@@ -1,4 +1,4 @@
-# DeepVista sync — prototype
+# DeepVista sync
 
 Pushes catchup **entities** into [DeepVista](https://deepvista.ai) as context
 cards. Off unless a repo's config sets `deepvista.enabled: true`.
@@ -158,7 +158,7 @@ memory of having been pushed.
 | `title` | entity title |
 | `description` | markdown: summary, metadata line, per-week timeline, related entities |
 | `tags` | `catchup`, `repo:<label>`, `category:<key>`, `entity:<id>`, plus the entity's own |
-| `status` | `confirmed` — see the gotcha |
+| `status` | `active` (`deepvista.card_status`) — see the gotcha |
 
 Entity type → DeepVista `card_type`. The right-hand column is DeepVista's fixed
 vocabulary, so the mapping is lossy on purpose:
@@ -185,9 +185,11 @@ can be traced back to its entity even if its title is edited in the product.
 
 **Agent-created cards default to `unconfirmed`, and search filters those out** —
 so a card pushed without an explicit status exists but is not findable. Every
-card this bridge sends therefore sets `status: "confirmed"`. Leave
-`deepvista.card_status` alone unless you specifically want cards staged for
-review.
+card this bridge sends therefore sets an explicit status — `active` by default,
+which is the served enum's "live" value and is searchable. (`confirmed`, which
+the first draft of this bridge sent, is *not* in the enum; a config still
+saying it is mapped to `active`.) Leave `deepvista.card_status` alone unless
+you specifically want cards staged for review.
 
 ## First live push — 2026-09-02, verified
 
@@ -432,4 +434,3 @@ those entities are the ones whose value compounds.
 delta for one card, and whether search found it.
 
 ---
-

--- a/.claude/skills/catchup/reference/portability.md
+++ b/.claude/skills/catchup/reference/portability.md
@@ -34,12 +34,43 @@ and says which of the three cases the repo is in:
 |---|---|
 | symlink | Fine. The pointer picks up whatever was just deployed. |
 | **copied directory** | **Broken.** The other runtime reads the stale copy, not canon. |
-| absent, but `AGENTS.md` present | The other runtime cannot see the skill at all yet. |
+| absent, `AGENTS.md` routes to `.claude/skills/` | Works — by prose, so it holds only while that sentence stays true. `deploy.py` says so |
+| absent, `AGENTS.md` silent | The other runtime cannot see the skill at all yet. |
 
 `deploy.py` also writes a `.deployed.json` manifest into the target recording
 what it put there. On the next run it compares against that, so it can tell a
 target that is merely *different* from one that is *ahead* — and refuses rather
 than overwriting work the target gained after the copy.
+
+**Commit the manifest.** It names the source by commit, never by path, so it
+carries nothing machine-specific — and ignored, it exists only on the machine
+that deployed, which puts every other clone back to "unknown" and lets the next
+deploy there overwrite whatever it finds. `deploy.py` warns when a target
+ignores it.
+
+## A deploy lands on a branch, never in a main checkout
+
+`deploy.py` writes files and nothing else. It does not commit, so whatever it
+leaves in the target is the caller's to commit and put on a pull request — and
+when the target checkout was on its default branch, nobody did: three repos
+were found weeks later with an uncommitted skill sitting in their main checkout,
+and the rescue was three pull requests of files nobody could date.
+
+So the script **refuses to write into a checkout that is on its default branch**,
+in either direction (a `--pull-back` writes into the source, and the source is a
+checkout too). There is no override; the branch is the fix, and `--branch <name>`
+makes it the easy one — a worktree under `.claude/worktrees/<name>` on a fresh
+branch from origin's default, created if needed and reused if not:
+
+```bash
+uv run .claude/skills/catchup/scripts/deploy.py <repo> --branch catchup-sync
+```
+
+After a deploy the script lists what is now uncommitted and the commands to
+land it. Two more things it checks in the target, because both are how a repo
+quietly accumulates untracked files: `__pycache__/` must be ignored (running
+the scripts writes one), and `.claude/worktrees/` must be ignored (or the
+worktree itself shows up as an untracked directory in the main checkout).
 
 The fix for a copied directory is always the same:
 

--- a/.claude/skills/catchup/scripts/deepvista_cards.py
+++ b/.claude/skills/catchup/scripts/deepvista_cards.py
@@ -85,12 +85,37 @@ from entities import (  # noqa: E402
 # app owns the token, so re-auth happens on the app's terms, not `~/.mcp-auth`'s.
 MCP_SERVER_NAME = "deepvista"
 MCP_ENDPOINT = "https://api.deepvista.ai/mcp"
-MCP_ENTRY_PROXY = {"command": "npx", "args": ["-y", "mcp-remote", MCP_ENDPOINT]}
+# The proxy is PINNED. `npx -y mcp-remote` resolves to whatever npm published
+# last, and this script hands that code a cached OAuth token and reads private
+# card bodies through it -- an unpinned package there is a supply-chain hole
+# with a login attached. Bump deliberately, in one place, after reading the
+# release; `install-mcp --force` re-pins an entry that predates the pin.
+MCP_REMOTE_PKG = "mcp-remote@0.8.3"
+MCP_ENTRY_PROXY = {"command": "npx", "args": ["-y", MCP_REMOTE_PKG, MCP_ENDPOINT]}
 # npm 6's npx cannot run the proxy entry: it does not understand `-y`.
 MCP_MIN_NPX = 7
 MCP_ENTRY_HTTP = {"type": "http", "url": MCP_ENDPOINT}
 MCP_ENTRIES = {"mcp-remote": MCP_ENTRY_PROXY, "http": MCP_ENTRY_HTTP}
 MCP_RELPATH = ".mcp.json"
+
+
+def entry_form(entry):
+    """Which transport an .mcp.json entry is, ignoring the proxy's pin.
+
+    An exact match against MCP_ENTRIES is too strict once the proxy package is
+    pinned: a repo carrying the pre-pin `mcp-remote` entry is the SAME form at a
+    different version, not a different transport, and should be told to re-pin
+    rather than that it conflicts.
+    """
+    if not isinstance(entry, dict):
+        return None
+    if entry.get("type") == "http" and entry.get("url") == MCP_ENDPOINT:
+        return "http"
+    args = entry.get("args") or []
+    if (entry.get("command") == "npx" and MCP_ENDPOINT in args
+            and any(str(a).split("@")[0] == "mcp-remote" for a in args)):
+        return "mcp-remote"
+    return None
 MCP_MIN_NODE = 18
 
 
@@ -235,7 +260,7 @@ class McpClient:
         # node child npx spawns. Terminating npx alone left the proxy running
         # after the first probes.
         self.proc = subprocess.Popen(
-            [self.npx, "-y", "mcp-remote", self.endpoint],
+            [self.npx, "-y", MCP_REMOTE_PKG, self.endpoint],
             stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
             text=True, bufsize=1, start_new_session=True)
         self._lines = []          # stdout, JSON-RPC
@@ -605,7 +630,7 @@ def cmd_install_mcp(args, repo, cfg, sdir):
     key, entry, why = choose_transport(args.transport)
 
     if args.scope == "user":
-        cmd = (f"claude mcp add {MCP_SERVER_NAME} -- npx -y mcp-remote {MCP_ENDPOINT}"
+        cmd = (f"claude mcp add {MCP_SERVER_NAME} -- npx -y {MCP_REMOTE_PKG} {MCP_ENDPOINT}"
                if key == "mcp-remote" else
                f"claude mcp add --transport http {MCP_SERVER_NAME} {MCP_ENDPOINT}")
         print(f"Transport: {key} ({why})\n")
@@ -638,11 +663,15 @@ def cmd_install_mcp(args, repo, cfg, sdir):
         # common case for this branch is a repo carrying the entry for a
         # transport this machine cannot run -- which is a one-flag fix, not a
         # mystery worth reading the source over.
-        other = next((k for k, v in MCP_ENTRIES.items() if v == existing), None)
-        hint = (f"\nThat is the {other} form and this machine resolved to {key}."
-                f"\nRe-run with --force to switch it, or --transport {other} to keep it."
-                if other and other != key else
-                "\nLeaving it alone -- pass --force to replace it.")
+        other = entry_form(existing)
+        if other == key == "mcp-remote":
+            hint = (f"\nSame proxy form, different package pin -- this skill pins "
+                    f"{MCP_REMOTE_PKG}.\nRe-run with --force to re-pin it.")
+        elif other and other != key:
+            hint = (f"\nThat is the {other} form and this machine resolved to {key}."
+                    f"\nRe-run with --force to switch it, or --transport {other} to keep it.")
+        else:
+            hint = "\nLeaving it alone -- pass --force to replace it."
         die(f"{MCP_SERVER_NAME} is already in {MCP_RELPATH} with different settings:\n"
             f"  {json.dumps(existing)}\n"
             f"expected:\n  {json.dumps(entry)}" + hint)
@@ -718,8 +747,12 @@ def cmd_doctor(args, repo, cfg, sdir):
             print(f"        -> run: install-mcp --repo {repo}")
             ok = False
         else:
-            key = next((k for k, v in MCP_ENTRIES.items() if v == entry), None)
+            key = entry_form(entry)
             print(f"  OK    {MCP_SERVER_NAME} -> {json.dumps(entry)}")
+            if key == "mcp-remote" and entry != MCP_ENTRY_PROXY:
+                print(f"  note  the proxy is not pinned to {MCP_REMOTE_PKG}; the host app will")
+                print("        run whatever npm publishes next, with the cached sign-in.")
+                print(f"        -> install-mcp --repo {repo} --force   (re-pins it)")
             if key is None:
                 print("  note  that is neither known form; it may still be valid, but this")
                 print("        script cannot vouch for it.")
@@ -905,7 +938,7 @@ def cmd_plan(args, repo, cfg, sdir):
     }, indent=2))
 
 
-def _mentions(text, entity):
+def _mentions(text, entity, week=None):
     """Whether a summary actually refers to this entity.
 
     Title first, then the distinctive half of the id -- a summary that says
@@ -920,8 +953,14 @@ def _mentions(text, entity):
     # every "What we learned" bullet with the claim sentence and carries the
     # title nowhere. Title-only matching scored all four concept rows of the
     # first control run as "only the DeepVista summary" when the local one had
-    # every one of them, one line each. Match the claim's opening too.
-    for wk in (entity.get("weeks") or {}).values():
+    # every one of them, one line each. Match the claim's opening too -- but only
+    # THIS week's claim when a week is given. A concept that carries claims from
+    # earlier weeks would otherwise count as covered because last month's
+    # sentence is in this week's summary, which is false coverage of exactly the
+    # kind the compare exists to catch.
+    weeks = entity.get("weeks") or {}
+    scope = [weeks[week]] if week and week in weeks else list(weeks.values())
+    for wk in scope:
         claim = (wk.get("claim") or "").strip().rstrip(".").lower()
         if len(claim) > 24 and claim[:60] in low:
             return True
@@ -958,7 +997,7 @@ def cmd_compare(args, repo, cfg, sdir):
 
     rows = []
     for e in sorted(ents, key=lambda x: (x.get("type", ""), x["id"])):
-        rows.append((e, _mentions(ours, e), _mentions(theirs, e)))
+        rows.append((e, _mentions(ours, e, args.week), _mentions(theirs, e, args.week)))
 
     both = [r for r in rows if r[1] and r[2]]
     only_ours = [r for r in rows if r[1] and not r[2]]

--- a/.claude/skills/catchup/scripts/deploy.py
+++ b/.claude/skills/catchup/scripts/deploy.py
@@ -160,11 +160,18 @@ def ensure_worktree(repo, name):
               f"(branch {current_branch(path) or 'DETACHED'})")
         return path
     os.makedirs(os.path.dirname(path), exist_ok=True)
+    subprocess.run(["git", "-C", repo, "fetch", "-q", "origin"], capture_output=True)
     if git(repo, "rev-parse", "--verify", "-q", f"refs/heads/{name}", ok_fail=True):
         git(repo, "worktree", "add", path, name)
         print(f"worktree: checked out existing branch {name} at {os.path.relpath(path, repo)}")
+    elif git(repo, "rev-parse", "--verify", "-q", f"refs/remotes/origin/{name}", ok_fail=True):
+        # A branch that exists only on the remote -- an open PR pushed from
+        # another checkout -- is that branch, not a new one with its name. The
+        # first real run of this flag would otherwise have branched three PR
+        # names off main and deployed beside the PRs instead of into them.
+        git(repo, "worktree", "add", "--track", "-b", name, path, f"origin/{name}")
+        print(f"worktree: checked out origin/{name} at {os.path.relpath(path, repo)} (tracking)")
     else:
-        subprocess.run(["git", "-C", repo, "fetch", "-q", "origin"], capture_output=True)
         default = default_branch(repo)
         base = f"origin/{default}" if default and git(
             repo, "rev-parse", "--verify", "-q", f"refs/remotes/origin/{default}",

--- a/.claude/skills/catchup/scripts/deploy.py
+++ b/.claude/skills/catchup/scripts/deploy.py
@@ -4,19 +4,29 @@
 # dependencies = []
 # ///
 """
-Move the catchup skill between its source of truth and a target repo.
+Move a skill between its source of truth and a target repo.
 
 The skill is edited in one place and copied into the repos that run it. Copies
 drift -- so this goes BOTH ways, because in practice defects are found where the
 skill RUNS, not where it is edited, and a one-way deploy turns every such fix
 into a manual transcription.
 
-    deploy.py <repo>              # source -> repo
-    deploy.py <repo> --config     # ...and seed catchup.config.json if absent
-    deploy.py <repo> --check      # compare only; exit 1 if they differ
-    deploy.py <repo> --pull-back  # repo -> source (the reverse review)
+    deploy.py <repo>                    # source -> repo
+    deploy.py <repo> --branch <name>    # ...into a worktree of <repo> on branch <name>
+    deploy.py <repo> --config           # ...and seed the config file if absent
+    deploy.py <repo> --check            # compare only; exit 1 if they differ
+    deploy.py <repo> --pull-back        # repo -> source (the reverse review)
     deploy.py <repo> --dry-run
     deploy.py --check-all <repo> [<repo> ...]
+
+A deploy WRITES into a checkout and does nothing else: no commit, no branch.
+Whatever it leaves behind is the caller's to commit -- and when the checkout
+was on its default branch, nobody did. Three repos were found weeks later with
+an uncommitted skill sitting in their main checkout, and the rescue was three
+pull requests of files nobody could date. So this script refuses to write into
+a checkout that is on its default branch, in EITHER direction, and `--branch`
+makes the right shape the easy one: a worktree under `.claude/worktrees/<name>`
+on a fresh branch, which is the only edit surface an agent session should have.
 """
 
 import argparse
@@ -26,6 +36,7 @@ import hashlib
 import json
 import os
 import shutil
+import subprocess
 import sys
 
 SCRIPT = os.path.abspath(__file__)
@@ -38,9 +49,14 @@ SELF_NAME = os.path.basename(SCRIPT)
 # Which skill is being moved. Defaults to the one this script ships inside, so
 # the common case needs no flag -- but the rollup skill has the same problem and
 # now lives in a second repo, and a copy nobody can check for drift is how the
-# whole class of bug this script exists for gets reintroduced.
+# whole class of bug this script exists for gets reintroduced. The two copies of
+# THIS file are kept identical by hand; `diff` them when either changes.
 SKILL_NAME = os.path.basename(SRC_SKILL)
 PARTS = ["SKILL.md", "assets", "reference", "scripts"]
+# The slash-command file travels with the skill when the source has one. It
+# lives outside the skill directory, so it is compared on its own.
+COMMAND_REL = os.path.join(".claude", "commands", f"{SKILL_NAME}.md")
+WORKTREES_REL = os.path.join(".claude", "worktrees")
 
 # What the last deploy put there, hashed. Without it a deploy cannot tell which
 # side is newer -- it sees only that two files differ -- so it happily
@@ -48,6 +64,11 @@ PARTS = ["SKILL.md", "assets", "reference", "scripts"]
 # deploy run straight after merging a branch into a consuming repo destroyed the
 # two fixes that merge existed to bring in, and the merge commit still looked
 # clean because the files it touched were the ones the deploy replaced.
+#
+# The manifest is meant to be COMMITTED in the target. Ignored, it exists only
+# on the machine that deployed, and every other clone is back to "unknown".
+# It records the source by commit, never by path: a path is machine-local and
+# says nothing about which version of the skill this is.
 MANIFEST = ".deployed.json"
 
 
@@ -55,6 +76,119 @@ def die(msg, code=1):
     print(f"deploy: {msg}", file=sys.stderr)
     sys.exit(code)
 
+
+# --- git ---------------------------------------------------------------------
+
+def git(repo, *args, ok_fail=False):
+    """stdout of a git command in `repo`, stripped; None on failure if ok_fail."""
+    p = subprocess.run(["git", "-C", repo, *args], capture_output=True, text=True)
+    if p.returncode != 0:
+        if ok_fail:
+            return None
+        die(f"git {' '.join(args)} failed in {repo}: {p.stderr.strip()}")
+    return p.stdout.strip()
+
+
+def current_branch(repo):
+    """Branch name, or None on a detached HEAD."""
+    return git(repo, "symbolic-ref", "--short", "-q", "HEAD", ok_fail=True) or None
+
+
+def default_branch(repo):
+    """What `origin/HEAD` points at, else main/master if either exists, else None."""
+    ref = git(repo, "symbolic-ref", "--short", "-q", "refs/remotes/origin/HEAD", ok_fail=True)
+    if ref:
+        return ref.split("/", 1)[1] if "/" in ref else ref
+    for name in ("main", "master"):
+        if git(repo, "rev-parse", "--verify", "-q", f"refs/heads/{name}", ok_fail=True):
+            return name
+    return None
+
+
+def guard_branch(repo, what):
+    """Refuse to write into a checkout on its default branch, or on no branch.
+
+    The point of the whole script is that a deploy is reviewable: it lands on a
+    branch, gets committed there, and arrives on main through a pull request
+    like any other change. Written straight into the main checkout it is none
+    of those things -- it is uncommitted cruft that `git status` shows and
+    nobody reads, until a later session finds it and has to guess where it came
+    from. There is no flag to override this; the branch is the fix.
+    """
+    branch = current_branch(repo)
+    if branch is None:
+        die(f"REFUSING to {what} {repo}: detached HEAD. Check out a branch first.")
+    default = default_branch(repo)
+    if default and branch == default:
+        rel = os.path.join(WORKTREES_REL, "<name>")
+        die(f"REFUSING to {what} {repo}: its checkout is on '{default}', the default branch.\n"
+            "  A deploy leaves uncommitted files behind, and on the default branch those\n"
+            "  are cruft nobody will find until they get in the way. Put it on a branch:\n"
+            f"    {SELF_NAME} {repo} --branch <name>      # worktree at {rel}\n"
+            "  or hand it a worktree you made yourself:\n"
+            f"    git -C {repo} worktree add -b <name> {rel}\n"
+            f"    {SELF_NAME} {os.path.join(repo, rel)}")
+    return branch
+
+
+def dirty(repo, paths):
+    """Uncommitted changes (tracked or not) under `paths`, as porcelain lines."""
+    existing = [p for p in paths if os.path.exists(os.path.join(repo, p))]
+    if not existing:
+        return []
+    out = git(repo, "status", "--porcelain", "--untracked-files=all", "--", *existing,
+              ok_fail=True) or ""
+    return [ln for ln in out.splitlines() if ln.strip()]
+
+
+def is_ignored(repo, rel):
+    p = subprocess.run(["git", "-C", repo, "check-ignore", "-q", rel], capture_output=True)
+    return p.returncode == 0
+
+
+def ensure_worktree(repo, name):
+    """A worktree of `repo` at .claude/worktrees/<name> on branch <name>.
+
+    Reused if it already exists. Otherwise created from origin's default branch
+    when that ref is known (after a best-effort fetch), else from HEAD -- so a
+    deploy starts from what main actually is, not from wherever the primary
+    checkout happened to be left.
+    """
+    path = os.path.join(repo, WORKTREES_REL, name)
+    if os.path.isdir(path) and os.path.exists(os.path.join(path, ".git")):
+        print(f"worktree: using existing {os.path.relpath(path, repo)} "
+              f"(branch {current_branch(path) or 'DETACHED'})")
+        return path
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    if git(repo, "rev-parse", "--verify", "-q", f"refs/heads/{name}", ok_fail=True):
+        git(repo, "worktree", "add", path, name)
+        print(f"worktree: checked out existing branch {name} at {os.path.relpath(path, repo)}")
+    else:
+        subprocess.run(["git", "-C", repo, "fetch", "-q", "origin"], capture_output=True)
+        default = default_branch(repo)
+        base = f"origin/{default}" if default and git(
+            repo, "rev-parse", "--verify", "-q", f"refs/remotes/origin/{default}",
+            ok_fail=True) else "HEAD"
+        git(repo, "worktree", "add", "-b", name, path, base)
+        print(f"worktree: created {os.path.relpath(path, repo)} on new branch {name} from {base}")
+    if not is_ignored(repo, os.path.join(WORKTREES_REL, name)):
+        print(f"  WARNING: {WORKTREES_REL}/ is not ignored in {repo}, so the worktree itself")
+        print("           shows up as an untracked directory in the main checkout.")
+        print(f"           Add `/{WORKTREES_REL}` to its .gitignore.")
+    return path
+
+
+def source_stamp():
+    """Which version of the skill this is -- by commit, never by path."""
+    return {
+        "skill": SKILL_NAME,
+        "commit": git(SRC_ROOT, "rev-parse", "--short=12", "HEAD", ok_fail=True),
+        "branch": current_branch(SRC_ROOT),
+        "dirty": bool(dirty(SRC_ROOT, [os.path.relpath(SRC_SKILL, SRC_ROOT)])),
+    }
+
+
+# --- comparing ---------------------------------------------------------------
 
 def resolve_target(path):
     t = os.path.abspath(os.path.expanduser(path))
@@ -90,7 +224,7 @@ def digest(path):
 def write_manifest(tskill):
     """Record what this deploy put there, so the next one can tell it apart."""
     body = {"deployed": dt.datetime.now(dt.timezone.utc).isoformat(timespec="seconds"),
-            "source": SRC_ROOT,
+            "source": source_stamp(),
             "files": {r: digest(os.path.join(tskill, r)) for r in sorted(walk(tskill))}}
     with open(os.path.join(tskill, MANIFEST), "w") as fh:
         json.dump(body, fh, indent=2)
@@ -137,14 +271,26 @@ def differences(tskill):
     return sorted(a - b), sorted(b - a), diff
 
 
+def command_state(target):
+    """How the slash-command file compares: None (same or n/a), 'missing', 'differs'."""
+    src = os.path.join(SRC_ROOT, COMMAND_REL)
+    if not os.path.isfile(src):
+        return None
+    dst = os.path.join(target, COMMAND_REL)
+    if not os.path.isfile(dst):
+        return "missing in target"
+    return None if filecmp.cmp(src, dst, shallow=False) else "differs"
+
+
 def report(tskill, target):
     d = differences(tskill)
     if d is None:
         print(f"not deployed: {tskill}")
         return 1
     only_src, only_tgt, changed = d
+    cmd = command_state(target)
     local = local_changes(tskill)
-    if not (only_src or only_tgt or changed):
+    if not (only_src or only_tgt or changed or cmd):
         print(f"in sync: {target}")
         return 0
     if local:
@@ -152,7 +298,7 @@ def report(tskill, target):
         for rel, how in local:
             print(f"  {how:<22} {rel}")
         print()
-        print(f"  Carry it home:  deploy.py {target} --pull-back")
+        print(f"  Carry it home:  {SELF_NAME} {target} --pull-back")
         print("  A deploy would overwrite these.")
         return 1
     print(f"DRIFT between source and {target}:")
@@ -162,11 +308,15 @@ def report(tskill, target):
         print(f"  missing in target {r}")
     for r in only_tgt:
         print(f"  only in target    {r}")
+    if cmd:
+        print(f"  {cmd:<17} {COMMAND_REL}")
     print()
-    print(f"  source -> target:  deploy.py {target}")
-    print(f"  target -> source:  deploy.py {target} --pull-back")
+    print(f"  source -> target:  {SELF_NAME} {target} --branch <name>")
+    print(f"  target -> source:  {SELF_NAME} {target} --pull-back")
     return 1
 
+
+# --- moving ------------------------------------------------------------------
 
 def copy_part(src, dst, dry):
     if dry:
@@ -191,9 +341,13 @@ def do_pull_back(target, tskill, dry):
     if d is None:
         die(f"nothing deployed at {tskill}")
     only_src, only_tgt, changed = d
-    if not (only_src or only_tgt or changed):
+    cmd = command_state(target)
+    if not (only_src or only_tgt or changed or cmd):
         print("already in sync — nothing to pull back")
         return
+    # The source is a checkout too, and a pull-back writes into it. Same rule.
+    if not dry:
+        guard_branch(SRC_ROOT, "pull back into the source at")
     print(f"pull back: {target} -> source")
     for r in changed:
         print(f"  differs        {r}")
@@ -201,6 +355,8 @@ def do_pull_back(target, tskill, dry):
         print(f"  new in target  {r}")
     for r in only_src:
         print(f"  WOULD DELETE   {r}  (present in source, absent in target)")
+    if cmd == "differs":
+        print(f"  differs        {COMMAND_REL}")
 
     # Preserve this script by CONTENT. Restoring it from git would silently
     # discard uncommitted edits to deploy.py itself -- which is exactly what the
@@ -214,6 +370,8 @@ def do_pull_back(target, tskill, dry):
         s = os.path.join(tskill, part)
         if os.path.exists(s):
             copy_part(s, os.path.join(SRC_SKILL, part), dry)
+    if cmd == "differs":
+        copy_part(os.path.join(target, COMMAND_REL), os.path.join(SRC_ROOT, COMMAND_REL), dry)
 
     if keep is not None:
         os.makedirs(os.path.dirname(SCRIPT), exist_ok=True)
@@ -230,12 +388,13 @@ def do_pull_back(target, tskill, dry):
     print()
     print("  Now REVIEW before committing — this overwrote canon with a copy,")
     print("  and a target that is BEHIND source would regress it:")
-    print(f"    git -C {SRC_ROOT} diff -- .claude/skills/{SKILL_NAME}")
+    print(f"    git -C {SRC_ROOT} diff -- .claude/skills/{SKILL_NAME} {COMMAND_REL}")
 
 
 def check_runtime_pointer(target):
     """Whether another agent runtime can reach what was just deployed."""
     ag = os.path.join(target, ".agents", "skills")
+    agents_md = os.path.join(target, "AGENTS.md")
     if os.path.islink(ag):
         print(f"  codex: .agents/skills -> {os.readlink(ag)} "
               "(pointer — picks this up automatically)")
@@ -243,17 +402,60 @@ def check_runtime_pointer(target):
         print("  WARNING: .agents/skills is a COPIED DIRECTORY, not a symlink.")
         print("           Codex reads that stale copy, not what was just deployed.")
         print("             rm -rf .agents/skills && ln -s ../.claude/skills .agents/skills")
-    elif os.path.exists(os.path.join(target, "AGENTS.md")):
-        print("  note: AGENTS.md exists but there is no .agents/skills pointer —")
-        print("        Codex cannot see this skill until one is added.")
+    elif os.path.exists(agents_md):
+        try:
+            routed = ".claude/skills" in open(agents_md, encoding="utf-8", errors="replace").read()
+        except OSError:
+            routed = False
+        if routed:
+            print("  codex: no .agents/skills pointer, but AGENTS.md routes to .claude/skills")
+            print("         (text, not a symlink — it works while that sentence stays true)")
+        else:
+            print("  note: AGENTS.md exists but neither points at .claude/skills nor has an")
+            print("        .agents/skills symlink — Codex cannot see this skill until one is added.")
+
+
+def check_hygiene(target):
+    """What running the skill here will leave behind, and whether git will notice."""
+    pyc = os.path.join(".claude", "skills", SKILL_NAME, "scripts", "__pycache__", "x.pyc")
+    if os.path.isdir(os.path.join(SRC_SKILL, "scripts")) and not is_ignored(target, pyc):
+        print("  WARNING: __pycache__/ is not ignored here. Running the scripts writes")
+        print(f"           .claude/skills/{SKILL_NAME}/scripts/__pycache__/, which then sits")
+        print("           untracked in the checkout. Add `__pycache__/` to .gitignore.")
+    if is_ignored(target, os.path.join(".claude", "skills", SKILL_NAME, MANIFEST)):
+        print(f"  WARNING: {MANIFEST} is ignored here. It is the record of what was deployed;")
+        print("           ignored, a fresh clone cannot tell a deploy from a local edit and")
+        print("           the next deploy overwrites whatever it finds. Commit it.")
 
 
 def do_deploy(target, tskill, want_config, dry, force=False):
+    if dry:
+        b, d = current_branch(target), default_branch(target)
+        if b is None or (d and b == d):
+            print(f"  note: a real run would REFUSE — {target} is on "
+                  f"{'no branch' if b is None else repr(b)}, and deploys need a branch.")
+    else:
+        guard_branch(target, "deploy into")
+
+    touched = [os.path.join(".claude", "skills", SKILL_NAME), COMMAND_REL,
+               os.path.join(".claude", f"{SKILL_NAME}.config.json")]
+    uncommitted = dirty(target, touched)
+
     # A deploy overwrites. If the target changed since it was last deployed to,
     # those changes are newer than the source and this would destroy them --
     # which is what happens right after a merge lands work in a consuming repo.
     if os.path.isdir(tskill):
         local = local_changes(tskill)
+        if local is None and uncommitted and not force:
+            print(f"REFUSING: {target} has uncommitted changes here and no deploy manifest,")
+            print("  so nothing can say whether they are an old deploy or someone's fix:")
+            for ln in uncommitted[:20]:
+                print(f"    {ln}")
+            print()
+            print(f"  If they are fixes:      {SELF_NAME} {target} --pull-back")
+            print("  If they are cruft:      commit or discard them, then re-run")
+            print("  Or overwrite anyway:    add --force")
+            return 1
         if local is None:
             print("  note: no deploy manifest here, so local changes cannot be")
             print("        detected. This deploy will overwrite whatever is there.")
@@ -263,9 +465,11 @@ def do_deploy(target, tskill, want_config, dry, force=False):
                 print(f"  {how:<22} {rel}")
             print()
             print("  These are NEWER than the source and a deploy would destroy them.")
-            print(f"  Carry them home first:  deploy.py {target} --pull-back")
+            print(f"  Carry them home first:  {SELF_NAME} {target} --pull-back")
             print("  Or overwrite anyway:    add --force")
             return 1
+        elif uncommitted:
+            print("  note: the previous deploy here was never committed; overwriting it.")
 
     print(f"deploy {SKILL_NAME} -> {target}")
     if not dry:
@@ -275,10 +479,9 @@ def do_deploy(target, tskill, want_config, dry, force=False):
             shutil.rmtree(tskill)
         shutil.copytree(SRC_SKILL, tskill,
                         ignore=shutil.ignore_patterns(SELF_NAME, "__pycache__"))
-        cmd = os.path.join(SRC_ROOT, ".claude", "commands", f"{SKILL_NAME}.md")
+        cmd = os.path.join(SRC_ROOT, COMMAND_REL)
         if os.path.isfile(cmd):
-            shutil.copy2(cmd, os.path.join(target, ".claude", "commands",
-                                           f"{SKILL_NAME}.md"))
+            shutil.copy2(cmd, os.path.join(target, COMMAND_REL))
     else:
         print(f"  would: copy skill -> {tskill} (excluding {SELF_NAME})")
 
@@ -298,7 +501,19 @@ def do_deploy(target, tskill, want_config, dry, force=False):
     if not dry:
         write_manifest(tskill)
     check_runtime_pointer(target)
+    check_hygiene(target)
     print(f"done: .claude/skills/{SKILL_NAME} in {target}")
+    if not dry:
+        left = dirty(target, touched)
+        print()
+        if left:
+            print(f"  {len(left)} file(s) now uncommitted on branch "
+                  f"'{current_branch(target)}'. This deploy is not done until they")
+            print("  are committed and on a pull request:")
+            print(f"    git -C {target} add {' '.join(touched)}")
+            print(f"    git -C {target} commit -m 'sync {SKILL_NAME} skill'")
+        else:
+            print("  nothing changed in the target — it already matched.")
     return 0
 
 
@@ -306,7 +521,11 @@ def main():
     ap = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("targets", nargs="+", help="target repo(s)")
-    ap.add_argument("--config", action="store_true", help="seed catchup.config.json if absent")
+    ap.add_argument("--branch", metavar="NAME",
+                    help=f"deploy into a worktree of the target at {WORKTREES_REL}/NAME "
+                         "on branch NAME (created from origin's default branch if new)")
+    ap.add_argument("--config", action="store_true",
+                    help=f"seed .claude/{SKILL_NAME}.config.json if absent")
     ap.add_argument("--check", action="store_true", help="compare only; exit 1 on drift")
     ap.add_argument("--check-all", action="store_true", help="check every target, exit 1 if any drift")
     ap.add_argument("--pull-back", action="store_true", help="target -> source (reverse review)")
@@ -317,12 +536,16 @@ def main():
 
     if args.pull_back and (args.check or args.check_all):
         die("--pull-back and --check are opposite directions; pick one")
+    if args.branch and (args.pull_back or args.check or args.check_all):
+        die("--branch is for deploys; point --check / --pull-back at the worktree path")
     if len(args.targets) > 1 and not args.check_all:
         die("multiple targets only make sense with --check-all")
 
     rc = 0
     for t in args.targets:
         target = resolve_target(t)
+        if args.branch:
+            target = ensure_worktree(target, args.branch)
         tskill = os.path.join(target, ".claude", "skills", SKILL_NAME)
         if args.check or args.check_all:
             rc |= report(tskill, target)

--- a/.claude/skills/rollup/SKILL.md
+++ b/.claude/skills/rollup/SKILL.md
@@ -50,10 +50,13 @@ The skill's **source of truth stays in the public repo**, and it is deployed
 here like any other:
 
 ```bash
-uv run .claude/skills/rollup/scripts/deploy.py <private-repo>
-uv run .claude/skills/rollup/scripts/deploy.py <private-repo> --check      # drifted?
-uv run .claude/skills/rollup/scripts/deploy.py <private-repo> --pull-back  # carry a fix home
+uv run .claude/skills/rollup/scripts/deploy.py <private-repo> --branch <name>   # into a worktree, on a branch
+uv run .claude/skills/rollup/scripts/deploy.py <private-repo> --check           # drifted?
+uv run .claude/skills/rollup/scripts/deploy.py <private-repo> --pull-back       # carry a fix home
 ```
+
+The same rule as the catchup deploy: it lands on a branch, never in the
+private repo's main checkout, and the script refuses the latter.
 
 It finds the registry by looking rather than assuming: `repos.json` at the repo
 root when running inside the private repo, `fnr/.private/repos.json` when
@@ -293,3 +296,8 @@ then the coverage buckets — and name what goes back to which repo.
 - **Reading the coverage diff before the fidelity row.** An entity that was
   never pushed is absent from the DeepVista summary by construction, not by
   judgment.
+- **Reading a compare whose store has moved on.** The fetch and compare run
+  against the *live* repo; the snapshot is kept as captured. When the two have
+  parted, the control row says `store moved on since capture` — either
+  `--recapture` so both sides are current, or read the buckets as
+  live-store-vs-captured-summary and say so in the rollup.

--- a/.claude/skills/rollup/scripts/deploy.py
+++ b/.claude/skills/rollup/scripts/deploy.py
@@ -160,11 +160,18 @@ def ensure_worktree(repo, name):
               f"(branch {current_branch(path) or 'DETACHED'})")
         return path
     os.makedirs(os.path.dirname(path), exist_ok=True)
+    subprocess.run(["git", "-C", repo, "fetch", "-q", "origin"], capture_output=True)
     if git(repo, "rev-parse", "--verify", "-q", f"refs/heads/{name}", ok_fail=True):
         git(repo, "worktree", "add", path, name)
         print(f"worktree: checked out existing branch {name} at {os.path.relpath(path, repo)}")
+    elif git(repo, "rev-parse", "--verify", "-q", f"refs/remotes/origin/{name}", ok_fail=True):
+        # A branch that exists only on the remote -- an open PR pushed from
+        # another checkout -- is that branch, not a new one with its name. The
+        # first real run of this flag would otherwise have branched three PR
+        # names off main and deployed beside the PRs instead of into them.
+        git(repo, "worktree", "add", "--track", "-b", name, path, f"origin/{name}")
+        print(f"worktree: checked out origin/{name} at {os.path.relpath(path, repo)} (tracking)")
     else:
-        subprocess.run(["git", "-C", repo, "fetch", "-q", "origin"], capture_output=True)
         default = default_branch(repo)
         base = f"origin/{default}" if default and git(
             repo, "rev-parse", "--verify", "-q", f"refs/remotes/origin/{default}",

--- a/.claude/skills/rollup/scripts/deploy.py
+++ b/.claude/skills/rollup/scripts/deploy.py
@@ -4,19 +4,29 @@
 # dependencies = []
 # ///
 """
-Move the catchup skill between its source of truth and a target repo.
+Move a skill between its source of truth and a target repo.
 
 The skill is edited in one place and copied into the repos that run it. Copies
 drift -- so this goes BOTH ways, because in practice defects are found where the
 skill RUNS, not where it is edited, and a one-way deploy turns every such fix
 into a manual transcription.
 
-    deploy.py <repo>              # source -> repo
-    deploy.py <repo> --config     # ...and seed catchup.config.json if absent
-    deploy.py <repo> --check      # compare only; exit 1 if they differ
-    deploy.py <repo> --pull-back  # repo -> source (the reverse review)
+    deploy.py <repo>                    # source -> repo
+    deploy.py <repo> --branch <name>    # ...into a worktree of <repo> on branch <name>
+    deploy.py <repo> --config           # ...and seed the config file if absent
+    deploy.py <repo> --check            # compare only; exit 1 if they differ
+    deploy.py <repo> --pull-back        # repo -> source (the reverse review)
     deploy.py <repo> --dry-run
     deploy.py --check-all <repo> [<repo> ...]
+
+A deploy WRITES into a checkout and does nothing else: no commit, no branch.
+Whatever it leaves behind is the caller's to commit -- and when the checkout
+was on its default branch, nobody did. Three repos were found weeks later with
+an uncommitted skill sitting in their main checkout, and the rescue was three
+pull requests of files nobody could date. So this script refuses to write into
+a checkout that is on its default branch, in EITHER direction, and `--branch`
+makes the right shape the easy one: a worktree under `.claude/worktrees/<name>`
+on a fresh branch, which is the only edit surface an agent session should have.
 """
 
 import argparse
@@ -26,6 +36,7 @@ import hashlib
 import json
 import os
 import shutil
+import subprocess
 import sys
 
 SCRIPT = os.path.abspath(__file__)
@@ -38,9 +49,14 @@ SELF_NAME = os.path.basename(SCRIPT)
 # Which skill is being moved. Defaults to the one this script ships inside, so
 # the common case needs no flag -- but the rollup skill has the same problem and
 # now lives in a second repo, and a copy nobody can check for drift is how the
-# whole class of bug this script exists for gets reintroduced.
+# whole class of bug this script exists for gets reintroduced. The two copies of
+# THIS file are kept identical by hand; `diff` them when either changes.
 SKILL_NAME = os.path.basename(SRC_SKILL)
 PARTS = ["SKILL.md", "assets", "reference", "scripts"]
+# The slash-command file travels with the skill when the source has one. It
+# lives outside the skill directory, so it is compared on its own.
+COMMAND_REL = os.path.join(".claude", "commands", f"{SKILL_NAME}.md")
+WORKTREES_REL = os.path.join(".claude", "worktrees")
 
 # What the last deploy put there, hashed. Without it a deploy cannot tell which
 # side is newer -- it sees only that two files differ -- so it happily
@@ -48,6 +64,11 @@ PARTS = ["SKILL.md", "assets", "reference", "scripts"]
 # deploy run straight after merging a branch into a consuming repo destroyed the
 # two fixes that merge existed to bring in, and the merge commit still looked
 # clean because the files it touched were the ones the deploy replaced.
+#
+# The manifest is meant to be COMMITTED in the target. Ignored, it exists only
+# on the machine that deployed, and every other clone is back to "unknown".
+# It records the source by commit, never by path: a path is machine-local and
+# says nothing about which version of the skill this is.
 MANIFEST = ".deployed.json"
 
 
@@ -55,6 +76,119 @@ def die(msg, code=1):
     print(f"deploy: {msg}", file=sys.stderr)
     sys.exit(code)
 
+
+# --- git ---------------------------------------------------------------------
+
+def git(repo, *args, ok_fail=False):
+    """stdout of a git command in `repo`, stripped; None on failure if ok_fail."""
+    p = subprocess.run(["git", "-C", repo, *args], capture_output=True, text=True)
+    if p.returncode != 0:
+        if ok_fail:
+            return None
+        die(f"git {' '.join(args)} failed in {repo}: {p.stderr.strip()}")
+    return p.stdout.strip()
+
+
+def current_branch(repo):
+    """Branch name, or None on a detached HEAD."""
+    return git(repo, "symbolic-ref", "--short", "-q", "HEAD", ok_fail=True) or None
+
+
+def default_branch(repo):
+    """What `origin/HEAD` points at, else main/master if either exists, else None."""
+    ref = git(repo, "symbolic-ref", "--short", "-q", "refs/remotes/origin/HEAD", ok_fail=True)
+    if ref:
+        return ref.split("/", 1)[1] if "/" in ref else ref
+    for name in ("main", "master"):
+        if git(repo, "rev-parse", "--verify", "-q", f"refs/heads/{name}", ok_fail=True):
+            return name
+    return None
+
+
+def guard_branch(repo, what):
+    """Refuse to write into a checkout on its default branch, or on no branch.
+
+    The point of the whole script is that a deploy is reviewable: it lands on a
+    branch, gets committed there, and arrives on main through a pull request
+    like any other change. Written straight into the main checkout it is none
+    of those things -- it is uncommitted cruft that `git status` shows and
+    nobody reads, until a later session finds it and has to guess where it came
+    from. There is no flag to override this; the branch is the fix.
+    """
+    branch = current_branch(repo)
+    if branch is None:
+        die(f"REFUSING to {what} {repo}: detached HEAD. Check out a branch first.")
+    default = default_branch(repo)
+    if default and branch == default:
+        rel = os.path.join(WORKTREES_REL, "<name>")
+        die(f"REFUSING to {what} {repo}: its checkout is on '{default}', the default branch.\n"
+            "  A deploy leaves uncommitted files behind, and on the default branch those\n"
+            "  are cruft nobody will find until they get in the way. Put it on a branch:\n"
+            f"    {SELF_NAME} {repo} --branch <name>      # worktree at {rel}\n"
+            "  or hand it a worktree you made yourself:\n"
+            f"    git -C {repo} worktree add -b <name> {rel}\n"
+            f"    {SELF_NAME} {os.path.join(repo, rel)}")
+    return branch
+
+
+def dirty(repo, paths):
+    """Uncommitted changes (tracked or not) under `paths`, as porcelain lines."""
+    existing = [p for p in paths if os.path.exists(os.path.join(repo, p))]
+    if not existing:
+        return []
+    out = git(repo, "status", "--porcelain", "--untracked-files=all", "--", *existing,
+              ok_fail=True) or ""
+    return [ln for ln in out.splitlines() if ln.strip()]
+
+
+def is_ignored(repo, rel):
+    p = subprocess.run(["git", "-C", repo, "check-ignore", "-q", rel], capture_output=True)
+    return p.returncode == 0
+
+
+def ensure_worktree(repo, name):
+    """A worktree of `repo` at .claude/worktrees/<name> on branch <name>.
+
+    Reused if it already exists. Otherwise created from origin's default branch
+    when that ref is known (after a best-effort fetch), else from HEAD -- so a
+    deploy starts from what main actually is, not from wherever the primary
+    checkout happened to be left.
+    """
+    path = os.path.join(repo, WORKTREES_REL, name)
+    if os.path.isdir(path) and os.path.exists(os.path.join(path, ".git")):
+        print(f"worktree: using existing {os.path.relpath(path, repo)} "
+              f"(branch {current_branch(path) or 'DETACHED'})")
+        return path
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    if git(repo, "rev-parse", "--verify", "-q", f"refs/heads/{name}", ok_fail=True):
+        git(repo, "worktree", "add", path, name)
+        print(f"worktree: checked out existing branch {name} at {os.path.relpath(path, repo)}")
+    else:
+        subprocess.run(["git", "-C", repo, "fetch", "-q", "origin"], capture_output=True)
+        default = default_branch(repo)
+        base = f"origin/{default}" if default and git(
+            repo, "rev-parse", "--verify", "-q", f"refs/remotes/origin/{default}",
+            ok_fail=True) else "HEAD"
+        git(repo, "worktree", "add", "-b", name, path, base)
+        print(f"worktree: created {os.path.relpath(path, repo)} on new branch {name} from {base}")
+    if not is_ignored(repo, os.path.join(WORKTREES_REL, name)):
+        print(f"  WARNING: {WORKTREES_REL}/ is not ignored in {repo}, so the worktree itself")
+        print("           shows up as an untracked directory in the main checkout.")
+        print(f"           Add `/{WORKTREES_REL}` to its .gitignore.")
+    return path
+
+
+def source_stamp():
+    """Which version of the skill this is -- by commit, never by path."""
+    return {
+        "skill": SKILL_NAME,
+        "commit": git(SRC_ROOT, "rev-parse", "--short=12", "HEAD", ok_fail=True),
+        "branch": current_branch(SRC_ROOT),
+        "dirty": bool(dirty(SRC_ROOT, [os.path.relpath(SRC_SKILL, SRC_ROOT)])),
+    }
+
+
+# --- comparing ---------------------------------------------------------------
 
 def resolve_target(path):
     t = os.path.abspath(os.path.expanduser(path))
@@ -90,7 +224,7 @@ def digest(path):
 def write_manifest(tskill):
     """Record what this deploy put there, so the next one can tell it apart."""
     body = {"deployed": dt.datetime.now(dt.timezone.utc).isoformat(timespec="seconds"),
-            "source": SRC_ROOT,
+            "source": source_stamp(),
             "files": {r: digest(os.path.join(tskill, r)) for r in sorted(walk(tskill))}}
     with open(os.path.join(tskill, MANIFEST), "w") as fh:
         json.dump(body, fh, indent=2)
@@ -137,14 +271,26 @@ def differences(tskill):
     return sorted(a - b), sorted(b - a), diff
 
 
+def command_state(target):
+    """How the slash-command file compares: None (same or n/a), 'missing', 'differs'."""
+    src = os.path.join(SRC_ROOT, COMMAND_REL)
+    if not os.path.isfile(src):
+        return None
+    dst = os.path.join(target, COMMAND_REL)
+    if not os.path.isfile(dst):
+        return "missing in target"
+    return None if filecmp.cmp(src, dst, shallow=False) else "differs"
+
+
 def report(tskill, target):
     d = differences(tskill)
     if d is None:
         print(f"not deployed: {tskill}")
         return 1
     only_src, only_tgt, changed = d
+    cmd = command_state(target)
     local = local_changes(tskill)
-    if not (only_src or only_tgt or changed):
+    if not (only_src or only_tgt or changed or cmd):
         print(f"in sync: {target}")
         return 0
     if local:
@@ -152,7 +298,7 @@ def report(tskill, target):
         for rel, how in local:
             print(f"  {how:<22} {rel}")
         print()
-        print(f"  Carry it home:  deploy.py {target} --pull-back")
+        print(f"  Carry it home:  {SELF_NAME} {target} --pull-back")
         print("  A deploy would overwrite these.")
         return 1
     print(f"DRIFT between source and {target}:")
@@ -162,11 +308,15 @@ def report(tskill, target):
         print(f"  missing in target {r}")
     for r in only_tgt:
         print(f"  only in target    {r}")
+    if cmd:
+        print(f"  {cmd:<17} {COMMAND_REL}")
     print()
-    print(f"  source -> target:  deploy.py {target}")
-    print(f"  target -> source:  deploy.py {target} --pull-back")
+    print(f"  source -> target:  {SELF_NAME} {target} --branch <name>")
+    print(f"  target -> source:  {SELF_NAME} {target} --pull-back")
     return 1
 
+
+# --- moving ------------------------------------------------------------------
 
 def copy_part(src, dst, dry):
     if dry:
@@ -191,9 +341,13 @@ def do_pull_back(target, tskill, dry):
     if d is None:
         die(f"nothing deployed at {tskill}")
     only_src, only_tgt, changed = d
-    if not (only_src or only_tgt or changed):
+    cmd = command_state(target)
+    if not (only_src or only_tgt or changed or cmd):
         print("already in sync — nothing to pull back")
         return
+    # The source is a checkout too, and a pull-back writes into it. Same rule.
+    if not dry:
+        guard_branch(SRC_ROOT, "pull back into the source at")
     print(f"pull back: {target} -> source")
     for r in changed:
         print(f"  differs        {r}")
@@ -201,6 +355,8 @@ def do_pull_back(target, tskill, dry):
         print(f"  new in target  {r}")
     for r in only_src:
         print(f"  WOULD DELETE   {r}  (present in source, absent in target)")
+    if cmd == "differs":
+        print(f"  differs        {COMMAND_REL}")
 
     # Preserve this script by CONTENT. Restoring it from git would silently
     # discard uncommitted edits to deploy.py itself -- which is exactly what the
@@ -214,6 +370,8 @@ def do_pull_back(target, tskill, dry):
         s = os.path.join(tskill, part)
         if os.path.exists(s):
             copy_part(s, os.path.join(SRC_SKILL, part), dry)
+    if cmd == "differs":
+        copy_part(os.path.join(target, COMMAND_REL), os.path.join(SRC_ROOT, COMMAND_REL), dry)
 
     if keep is not None:
         os.makedirs(os.path.dirname(SCRIPT), exist_ok=True)
@@ -230,12 +388,13 @@ def do_pull_back(target, tskill, dry):
     print()
     print("  Now REVIEW before committing — this overwrote canon with a copy,")
     print("  and a target that is BEHIND source would regress it:")
-    print(f"    git -C {SRC_ROOT} diff -- .claude/skills/{SKILL_NAME}")
+    print(f"    git -C {SRC_ROOT} diff -- .claude/skills/{SKILL_NAME} {COMMAND_REL}")
 
 
 def check_runtime_pointer(target):
     """Whether another agent runtime can reach what was just deployed."""
     ag = os.path.join(target, ".agents", "skills")
+    agents_md = os.path.join(target, "AGENTS.md")
     if os.path.islink(ag):
         print(f"  codex: .agents/skills -> {os.readlink(ag)} "
               "(pointer — picks this up automatically)")
@@ -243,17 +402,60 @@ def check_runtime_pointer(target):
         print("  WARNING: .agents/skills is a COPIED DIRECTORY, not a symlink.")
         print("           Codex reads that stale copy, not what was just deployed.")
         print("             rm -rf .agents/skills && ln -s ../.claude/skills .agents/skills")
-    elif os.path.exists(os.path.join(target, "AGENTS.md")):
-        print("  note: AGENTS.md exists but there is no .agents/skills pointer —")
-        print("        Codex cannot see this skill until one is added.")
+    elif os.path.exists(agents_md):
+        try:
+            routed = ".claude/skills" in open(agents_md, encoding="utf-8", errors="replace").read()
+        except OSError:
+            routed = False
+        if routed:
+            print("  codex: no .agents/skills pointer, but AGENTS.md routes to .claude/skills")
+            print("         (text, not a symlink — it works while that sentence stays true)")
+        else:
+            print("  note: AGENTS.md exists but neither points at .claude/skills nor has an")
+            print("        .agents/skills symlink — Codex cannot see this skill until one is added.")
+
+
+def check_hygiene(target):
+    """What running the skill here will leave behind, and whether git will notice."""
+    pyc = os.path.join(".claude", "skills", SKILL_NAME, "scripts", "__pycache__", "x.pyc")
+    if os.path.isdir(os.path.join(SRC_SKILL, "scripts")) and not is_ignored(target, pyc):
+        print("  WARNING: __pycache__/ is not ignored here. Running the scripts writes")
+        print(f"           .claude/skills/{SKILL_NAME}/scripts/__pycache__/, which then sits")
+        print("           untracked in the checkout. Add `__pycache__/` to .gitignore.")
+    if is_ignored(target, os.path.join(".claude", "skills", SKILL_NAME, MANIFEST)):
+        print(f"  WARNING: {MANIFEST} is ignored here. It is the record of what was deployed;")
+        print("           ignored, a fresh clone cannot tell a deploy from a local edit and")
+        print("           the next deploy overwrites whatever it finds. Commit it.")
 
 
 def do_deploy(target, tskill, want_config, dry, force=False):
+    if dry:
+        b, d = current_branch(target), default_branch(target)
+        if b is None or (d and b == d):
+            print(f"  note: a real run would REFUSE — {target} is on "
+                  f"{'no branch' if b is None else repr(b)}, and deploys need a branch.")
+    else:
+        guard_branch(target, "deploy into")
+
+    touched = [os.path.join(".claude", "skills", SKILL_NAME), COMMAND_REL,
+               os.path.join(".claude", f"{SKILL_NAME}.config.json")]
+    uncommitted = dirty(target, touched)
+
     # A deploy overwrites. If the target changed since it was last deployed to,
     # those changes are newer than the source and this would destroy them --
     # which is what happens right after a merge lands work in a consuming repo.
     if os.path.isdir(tskill):
         local = local_changes(tskill)
+        if local is None and uncommitted and not force:
+            print(f"REFUSING: {target} has uncommitted changes here and no deploy manifest,")
+            print("  so nothing can say whether they are an old deploy or someone's fix:")
+            for ln in uncommitted[:20]:
+                print(f"    {ln}")
+            print()
+            print(f"  If they are fixes:      {SELF_NAME} {target} --pull-back")
+            print("  If they are cruft:      commit or discard them, then re-run")
+            print("  Or overwrite anyway:    add --force")
+            return 1
         if local is None:
             print("  note: no deploy manifest here, so local changes cannot be")
             print("        detected. This deploy will overwrite whatever is there.")
@@ -263,9 +465,11 @@ def do_deploy(target, tskill, want_config, dry, force=False):
                 print(f"  {how:<22} {rel}")
             print()
             print("  These are NEWER than the source and a deploy would destroy them.")
-            print(f"  Carry them home first:  deploy.py {target} --pull-back")
+            print(f"  Carry them home first:  {SELF_NAME} {target} --pull-back")
             print("  Or overwrite anyway:    add --force")
             return 1
+        elif uncommitted:
+            print("  note: the previous deploy here was never committed; overwriting it.")
 
     print(f"deploy {SKILL_NAME} -> {target}")
     if not dry:
@@ -275,10 +479,9 @@ def do_deploy(target, tskill, want_config, dry, force=False):
             shutil.rmtree(tskill)
         shutil.copytree(SRC_SKILL, tskill,
                         ignore=shutil.ignore_patterns(SELF_NAME, "__pycache__"))
-        cmd = os.path.join(SRC_ROOT, ".claude", "commands", f"{SKILL_NAME}.md")
+        cmd = os.path.join(SRC_ROOT, COMMAND_REL)
         if os.path.isfile(cmd):
-            shutil.copy2(cmd, os.path.join(target, ".claude", "commands",
-                                           f"{SKILL_NAME}.md"))
+            shutil.copy2(cmd, os.path.join(target, COMMAND_REL))
     else:
         print(f"  would: copy skill -> {tskill} (excluding {SELF_NAME})")
 
@@ -298,7 +501,19 @@ def do_deploy(target, tskill, want_config, dry, force=False):
     if not dry:
         write_manifest(tskill)
     check_runtime_pointer(target)
+    check_hygiene(target)
     print(f"done: .claude/skills/{SKILL_NAME} in {target}")
+    if not dry:
+        left = dirty(target, touched)
+        print()
+        if left:
+            print(f"  {len(left)} file(s) now uncommitted on branch "
+                  f"'{current_branch(target)}'. This deploy is not done until they")
+            print("  are committed and on a pull request:")
+            print(f"    git -C {target} add {' '.join(touched)}")
+            print(f"    git -C {target} commit -m 'sync {SKILL_NAME} skill'")
+        else:
+            print("  nothing changed in the target — it already matched.")
     return 0
 
 
@@ -306,7 +521,11 @@ def main():
     ap = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("targets", nargs="+", help="target repo(s)")
-    ap.add_argument("--config", action="store_true", help="seed catchup.config.json if absent")
+    ap.add_argument("--branch", metavar="NAME",
+                    help=f"deploy into a worktree of the target at {WORKTREES_REL}/NAME "
+                         "on branch NAME (created from origin's default branch if new)")
+    ap.add_argument("--config", action="store_true",
+                    help=f"seed .claude/{SKILL_NAME}.config.json if absent")
     ap.add_argument("--check", action="store_true", help="compare only; exit 1 on drift")
     ap.add_argument("--check-all", action="store_true", help="check every target, exit 1 if any drift")
     ap.add_argument("--pull-back", action="store_true", help="target -> source (reverse review)")
@@ -317,12 +536,16 @@ def main():
 
     if args.pull_back and (args.check or args.check_all):
         die("--pull-back and --check are opposite directions; pick one")
+    if args.branch and (args.pull_back or args.check or args.check_all):
+        die("--branch is for deploys; point --check / --pull-back at the worktree path")
     if len(args.targets) > 1 and not args.check_all:
         die("multiple targets only make sense with --check-all")
 
     rc = 0
     for t in args.targets:
         target = resolve_target(t)
+        if args.branch:
+            target = ensure_worktree(target, args.branch)
         tskill = os.path.join(target, ".claude", "skills", SKILL_NAME)
         if args.check or args.check_all:
             rc |= report(tskill, target)

--- a/.claude/skills/rollup/scripts/rollup.py
+++ b/.claude/skills/rollup/scripts/rollup.py
@@ -491,11 +491,35 @@ def control_deepvista(d, out_dir, refetch=False):
     unless --refetch says otherwise -- a read is free, but a control whose
     evidence silently changed between the two runs is not a control.
     """
+    # The snapshot may be holding captured copies that the live repo has moved
+    # past (see snapshot()). The fetch and compare below run against the LIVE
+    # repo -- the catchup script owns the read of its own store -- so when a
+    # captured source has drifted, the control is being paired with newer
+    # evidence than the rollup was built from. That cannot be silently fine:
+    # it is recorded per repo and printed in the table.
+    mpath = os.path.join(out_dir, "sources.json")
+    try:
+        with open(mpath) as fh:
+            manifest = json.load(fh)
+    except (OSError, json.JSONDecodeError):
+        manifest = {"week": d["week"]}
+    drifted = {}
+    for src in manifest.get("sources") or []:
+        if not isinstance(src, dict):
+            continue
+        files = src.get("files") or {}
+        moved = sorted(f for f, meta in files.items()
+                       if isinstance(meta, dict) and meta.get("drift"))
+        if moved:
+            drifted[src.get("name")] = moved
+
     results = []
     for r in d["repos"]:
         if not r.get("has_record"):
             continue
         entry = {"name": r["name"], "enabled": False}
+        if drifted.get(r["name"]):
+            entry["snapshot_drift"] = drifted[r["name"]]
         cfg_path = os.path.join(r["path"], ".claude", "catchup.config.json")
         try:
             with open(cfg_path) as fh:
@@ -518,9 +542,21 @@ def control_deepvista(d, out_dir, refetch=False):
         cards_path = os.path.join(rd, CONTROL_CARDS)
 
         if refetch or not os.path.isfile(cards_path):
-            p = subprocess.run(_runner() + [script, "fetch", "--repo", r["path"],
-                                            "--week", d["week"], "--out", cards_path],
-                               capture_output=True, text=True, timeout=900)
+            # One repo's proxy hanging must cost that repo its row, not the
+            # rollup its run: a TimeoutExpired here used to unwind the whole
+            # control with the other repos' fetches already done and unrecorded.
+            try:
+                p = subprocess.run(_runner() + [script, "fetch", "--repo", r["path"],
+                                                "--week", d["week"], "--out", cards_path],
+                                   capture_output=True, text=True, timeout=900)
+            except subprocess.TimeoutExpired:
+                entry["error"] = "fetch timed out after 900s (proxy hung or sign-in pending)"
+                results.append(entry)
+                continue
+            except OSError as e:
+                entry["error"] = f"fetch could not start: {e}"
+                results.append(entry)
+                continue
             if p.returncode != 0:
                 entry["error"] = (p.stderr or p.stdout).strip()[-600:]
                 results.append(entry)
@@ -554,9 +590,25 @@ def control_deepvista(d, out_dir, refetch=False):
             results.append(entry)
             continue
         entry["summary"] = os.path.relpath(summary, PRIVATE_DIR)
-        p = subprocess.run(_runner() + [script, "compare", d["week"], "--repo", r["path"],
-                                        "--against", summary, "--json"],
-                           capture_output=True, text=True, timeout=300)
+        # The local side of the compare is the CAPTURED summary when the
+        # snapshot holds one, so the coverage diff is against what the rollup
+        # was built from. The entity store is still read live by the catchup
+        # script; `snapshot_drift` above says when that store has moved on.
+        cmd = _runner() + [script, "compare", d["week"], "--repo", r["path"],
+                           "--against", summary, "--json"]
+        captured = os.path.join(rd, "summary.md")
+        if os.path.isfile(captured):
+            cmd += ["--ours", captured]
+        try:
+            p = subprocess.run(cmd, capture_output=True, text=True, timeout=300)
+        except subprocess.TimeoutExpired:
+            entry["error"] = "compare timed out after 300s"
+            results.append(entry)
+            continue
+        except OSError as e:
+            entry["error"] = f"compare could not start: {e}"
+            results.append(entry)
+            continue
         if p.returncode != 0:
             entry["error"] = f"compare failed: {(p.stderr or p.stdout).strip()[-600:]}"
             results.append(entry)
@@ -577,12 +629,6 @@ def control_deepvista(d, out_dir, refetch=False):
         results.append(entry)
 
     # Into the manifest, beside the sources it is the control FOR.
-    mpath = os.path.join(out_dir, "sources.json")
-    try:
-        with open(mpath) as fh:
-            manifest = json.load(fh)
-    except (OSError, json.JSONDecodeError):
-        manifest = {"week": d["week"]}
     manifest["control"] = {"deepvista": {
         "run": dt.datetime.now().isoformat(timespec="seconds"),
         "files": [CONTROL_CARDS, CONTROL_SUMMARY, CONTROL_COMPARE],
@@ -625,6 +671,9 @@ def render_control(results):
             extra.append(f"{c['orphans']} orphan cards under tag")
         if c.get("not_found"):
             extra.append(f"{c['not_found']} not found")
+        if e.get("snapshot_drift"):
+            extra.append("store moved on since capture: " + ", ".join(e["snapshot_drift"])
+                         + " (--recapture, or read the compare as live-vs-captured)")
         out.append(f"  {str(e['name']):<16}{c.get('fetched', 0):>6}  {trs:<14}"
                    f"{bds:>12}  {cols}  "
                    + "; ".join([x for x in [note] if x] + extra))

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,11 +155,19 @@ omission to pull back into the source repo. It is also the fidelity check on
 the push — unpushed entities, orphan cards, bodies that drifted — which is
 where the first run found most of its findings.
 
-`catchup` is **deployed** into other repos, not run from here:
+`catchup` is **deployed** into other repos, not run from here — and always
+into a **branch** of the target, never its main checkout:
 
 ```bash
-.claude/skills/catchup/scripts/deploy.py /path/to/repo --config
+.claude/skills/catchup/scripts/deploy.py /path/to/repo --branch catchup-sync --config
 ```
+
+`--branch` puts the copy in a worktree of the target (`.claude/worktrees/<name>`)
+on a fresh branch; the script refuses a target that is sitting on its default
+branch, in either direction, because a deploy commits nothing and what it
+leaves in a main checkout is cruft until someone rescues it. Commit what the
+deploy leaves behind — the skill, the command file, and the `.deployed.json`
+manifest — and open a PR in that repo; the deploy is not done before that.
 
 Edit it here and redeploy — but **the copies go both ways**, because defects
 turn up where the skill *runs*, not where it is edited:
@@ -173,7 +181,8 @@ turn up where the skill *runs*, not where it is edited:
 before committing — pulling back from a target that is *behind* would regress
 the source. Never let another runtime hold a second copy either: `.agents/skills`
 must be a symlink, not a directory, and `deploy.py` reports which state a repo
-is in after every deploy.
+is in after every deploy. `rollup` has the same script at
+`.claude/skills/rollup/scripts/deploy.py`; the two files are kept identical.
 
 `rollup` output carries repo names and unscrubbed notes, so it is **private by
 construction**. Repo names live in `fnr/.private/repos.json` and nowhere else in


### PR DESCRIPTION
## What

Reconciles the canonical `catchup` skill against the copies that were rescued out of three consuming repos' main checkouts. Every rescued copy turned out to be a byte-identical deploy of what is now merged as #10 — one of them plus two whitespace-only edits. This branch is rebased on `main` with #10 in it, so what remains here is the set of fixes those rescue PRs asked for before they could land.

## Why deploys left cruft, and the guard

`deploy.py` writes files and commits nothing, and it was being pointed at main checkouts. Now:

- It **refuses a target whose checkout is on its default branch**, and refuses a `--pull-back` when the source is. No override flag — the branch is the fix.
- `--branch <name>` creates (from origin's default) or reuses a worktree at `.claude/worktrees/<name>` and deploys there, then lists what is uncommitted and the commands to land it.
- A target with uncommitted skill files and **no manifest** — the cruft case — is refused unless `--force`; with a manifest, an uncommitted previous deploy is overwritten with a note and a real local edit still refuses.
- `.deployed.json` records the source by commit and branch, never a machine path, and the docs now say to commit it. The script warns when a target ignores the manifest, does not ignore `__pycache__/`, or does not ignore `.claude/worktrees/`.
- `--branch <name>` follows a branch that exists only on the remote (an open PR pushed from elsewhere) instead of creating a new one with its name — found on the first real run against three PR branches.
- The slash-command file is part of the drift check, and `AGENTS.md` prose routing to `.claude/skills/` is recognised instead of warned about.
- The identical copy under `rollup/scripts/` is updated in step, and CLAUDE.md says the two are kept identical.

## Fixes to the control (the review items on #10)

- The headless proxy is **pinned** (`mcp-remote@0.8.3`) for `fetch` and for the `.mcp.json` entry; `install-mcp` and `doctor` recognise a pre-pin entry as the same form and say to re-pin. This repo's own `.mcp.json` is the `http` form and is unchanged.
- `compare` matches a learning's claim **for the week being compared only** — an earlier week's claim no longer counts as coverage.
- Rollup control: a fetch or compare timeout is one repo's error row, not an aborted run; compare uses the captured summary when the snapshot has one; a snapshot whose source moved on is flagged in the control table and the manifest.
- Docs: DeepVista reference no longer says "prototype"; card status is `active`, with `confirmed` documented as mapped; the SKILL.md note claiming `deploy.py` is not part of this skill is replaced by what the script actually does.
- Pulled back from a copy: a trailing-whitespace line in `config.md` and a trailing blank line in `deepvista.md`.

## Verified

- `deploy.py` against throwaway repos: refusal on the default branch, dry-run note, `--branch` create and reuse, in-sync / not-deployed / AHEAD / DRIFT reports, refuse-then-`--force`, dirty-without-manifest refusal, commit-then-redeploy no-op, main checkout left clean throughout.
- Week-scoped `_mentions` and `entry_form` unit-checked; every script compiles and runs `--help`; `git diff --check` clean.
- Each rescued copy drift-checked against this branch: the two plain deploys need a redeploy; the one with local edits reports AHEAD, and its edits are now in canon.

## Already run from this branch

Deployed from this branch into each of the three rescue PR branches, in worktrees, and committed there. Each PR now carries the reconciled skill; `--check` from this branch reports every one in sync. The main checkouts were never touched.

## After this lands

Redeploy into each consuming repo **on a branch** — `deploy.py <repo> --branch catchup-sync`, `--force` where the copy reports AHEAD — commit, and open that repo's PR. A consuming repo that carries the `mcp-remote` form in its `.mcp.json` gets the pin from `install-mcp --force`. Deliberately not done from here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

