### PR TITLE
Scope optional catchup MCP sync to explicit commands

### DIFF
--- a/.claude/skills/catchup/SKILL.md
+++ b/.claude/skills/catchup/SKILL.md
@@ -570,58 +570,37 @@ Only when config sets `deepvista.enabled: true`. See
 [`reference/deepvista.md`](reference/deepvista.md) for the full runbook —
 endpoint, auth, and the one gotcha that makes cards invisible if you miss it.
 
-**Register the server from the skill, not by hand.** The requirement travels
-with the code that has it:
+**Do not register DeepVista in `.mcp.json` or at user scope.** MCP hosts start
+registered servers at session creation, before the model chooses a tool, so a
+registration turns this optional catchup step into an OAuth/network side effect
+of every unrelated session. The bridge owns a pinned, short-lived proxy instead.
+
+Check the local runtime and endpoint explicitly:
 
 ```bash
-uv run $SKILL/deepvista_cards.py install-mcp --repo .            # writes .mcp.json
-uv run $SKILL/deepvista_cards.py install-mcp --repo . --scope user   # prints the once-per-machine command
+uv run $SKILL/deepvista_cards.py doctor --repo .
 ```
 
-Idempotent, writes **no credentials** — the server does OAuth 2.1 with dynamic
-client registration, so a repo file holds a name, a transport and a URL and
-nothing else. It refuses to overwrite a conflicting entry.
-
-It prefers the **`mcp-remote` proxy form**: that proxy runs the OAuth itself and
-caches the token under `~/.mcp-auth`, so one browser sign-in makes every later
-session headless — agent runs included. Handing the flow to the host app's own
-MCP client instead (`type: http`) means it can only be done wherever that app
-exposes a connect UI. The proxy costs a **Node 18+** dependency, since `npx`
-runs it.
-
-That preference is now **conditional on the runtime being there**. It used to be
-unconditional, which meant `install-mcp` would write an `npx` entry onto a
-machine with no Node, report success, and leave the failure to surface a session
-later as `deepvista (ENOENT): Executable not found in $PATH: npx`. `--transport
-auto` (the default) picks the form this machine can actually start;
-`--transport mcp-remote|http` forces one. Verify before trusting it:
-
-```bash
-uv run $SKILL/deepvista_cards.py doctor --repo .    # runtime + entry + endpoint; exits 1 on a break
-```
-
-The first sign-in is still a human step, and a *fresh* session is required
-because MCP servers connect at start-up. Sequence the work accordingly: an agent
-does `install-mcp` and `plan`, a human does the one browser flow, then an agent
-pushes — every time after that, an agent can do all of it.
-
-**No API key is required** — the server does MCP OAuth with dynamic client
-registration. Add the `.mcp.json` entry with no `headers`, then run `/mcp` in an
-**interactive** session and sign in through the browser; a non-interactive
-session has no prompt to answer. If a key path ever appears, it belongs in
-`~/.config/secrets.env`, exported before the session — never in a repo file and
-never read into the transcript.
+`doctor` is a deliberate network preflight. `plan` and a dry `push` are local;
+only `push --apply` and `fetch` start the proxy and contact DeepVista:
 
 ```bash
 uv run $SKILL/deepvista_cards.py plan --repo . --week 2026-W35
+uv run $SKILL/deepvista_cards.py push --repo . --week 2026-W35        # local preview
+uv run $SKILL/deepvista_cards.py push --repo . --week 2026-W35 --apply
 ```
 
-Emits one item per entity with `action: create | update | skip`. Call the
-DeepVista MCP card tool for each, then record what came back:
+The first applied command may need a human browser sign-in. `mcp-remote` caches
+that OAuth token under `~/.mcp-auth`; later explicit commands are headless. No
+DeepVista process remains attached to the host session.
 
-```bash
-uv run $SKILL/deepvista_cards.py record --repo . --id <entity-id> --card-id <returned>
-```
+**No API key is required** — the server does MCP OAuth with dynamic client
+registration. If a key path ever appears, it belongs in
+`~/.config/secrets.env`, exported before the session — never in a repo file and
+never read into the transcript.
+
+The push records each returned card id immediately. `record` remains only as a
+manual recovery command for a card created before local write-back completed.
 
 `skip` means the entity has not changed since its last push — **let it skip.**
 The free tier is 100 credits a month, and re-pushing an unchanged card spends
@@ -724,8 +703,8 @@ one-line fix: [`reference/portability.md`](reference/portability.md).
 
 The scripts are plain Python over `git` and `gh` with no runtime-specific calls,
 and `/catchup` is a convenience rather than the interface — the skill can be
-followed directly. The only model-called dependency is the optional DeepVista
-sync, which is off by default.
+followed directly. The only optional external dependency is the command-scoped
+DeepVista sync, which is off by default.
 
 ---
 

--- a/.claude/skills/catchup/reference/deepvista.md
+++ b/.claude/skills/catchup/reference/deepvista.md
@@ -6,8 +6,8 @@ cards. Off unless a repo's config sets `deepvista.enabled: true`.
 Status: **live, both directions.** The push was exercised against a live
 account on 2026-09-02 (see *First live push*), and the read-back — `fetch`,
 headless through the proxy — the same day, on 74 cards across two repos (see
-*Reading the week back*). The push half is still model-driven; the read half
-is a script.
+*Reading the week back*). Both directions now use an explicit, command-owned
+proxy; no host-level MCP registration is needed.
 
 ## Why one card per entity
 
@@ -42,28 +42,21 @@ project**. It exposes context-card read, search, create, update and delete.
 **No API key is needed.** The server implements the MCP OAuth flow with dynamic
 client registration, so the client registers itself and the browser does the rest.
 
-**Register it once at user scope, not per repo:**
+**Do not register it at project or user scope.** MCP hosts start registered
+servers when a session is created, so either scope makes an optional catchup
+integration contact DeepVista during unrelated analysis. The bridge instead
+starts the pinned proxy only inside `push --apply` and `fetch`, then tears it
+down.
 
 ```bash
-claude mcp add --transport http deepvista-server https://api.deepvista.ai/mcp
+uv run scripts/deepvista_cards.py doctor --repo .
+uv run scripts/deepvista_cards.py push --repo . --week 2026-W35       # local preview
+uv run scripts/deepvista_cards.py push --repo . --week 2026-W35 --apply
 ```
 
-Then, **in an interactive session**, run `/mcp`, pick `deepvista`, and complete
-the browser sign-in. A non-interactive session cannot do this — there is no
-prompt to answer.
-
-User scope makes the server available in every repo without a `.mcp.json`
-committed anywhere. Since auth is OAuth rather than a key, there is no secret to
-place and nothing repo-specific to keep in sync — which is the whole reason to
-prefer it over N copies of the same five-line config.
-
-A project-scoped `.mcp.json` works too and is right when a repo's collaborators
-should all get the server. For a personal integration, user scope is less to
-maintain and leaves no trace in the repo:
-
-```json
-{ "mcpServers": { "deepvista": { "type": "http", "url": "https://api.deepvista.ai/mcp" } } }
-```
+The first applied command may print an authorization URL and wait for the human
+browser flow. The proxy caches the resulting OAuth token under `~/.mcp-auth`;
+later explicit commands are headless. A dry push never starts the proxy.
 
 ### Which repo does the pushing
 
@@ -105,31 +98,16 @@ a bearer credential. It is not the thing to reach for here.
 
 `rm -rf ~/.mcp-auth` clears a stuck auth cache.
 
-### If a bearer key is used instead
-
-Follow the local-secrets convention rather than putting it in a repo file: keep
-it in `~/.config/secrets.env` as `DEEPVISTA_API_KEY`, never printed (transcripts
-get committed), and export it before starting the session so `.mcp.json` can
-interpolate `${DEEPVISTA_API_KEY}` inside a `headers` block:
-
-```bash
-set -a; . ~/.config/secrets.env; set +a
-```
-
-`.mcp.json` interpolates from the environment of the process that *starts* the
-server, so a key present in the file but never exported surfaces as an
-authentication failure rather than as a missing variable.
-
 ## The cycle
 
-`plan` and `record` are deterministic and live in a script. The MCP calls in
-between are made by the model, because MCP tools are model-called — a shell
-script cannot make them.
+`plan` and dry `push` are deterministic previews. Only the `--apply` form opens
+the MCP connection and writes cards; it records each returned id immediately so
+a partial run can resume without duplicating completed creates.
 
 ```bash
 uv run scripts/deepvista_cards.py plan --repo . --week 2026-W35
-#   → [model calls the DeepVista MCP card tool per item]
-uv run scripts/deepvista_cards.py record --repo . --id <entity> --card-id <returned>
+uv run scripts/deepvista_cards.py push --repo . --week 2026-W35
+uv run scripts/deepvista_cards.py push --repo . --week 2026-W35 --apply
 ```
 
 Each plan item carries `action`:
@@ -145,10 +123,9 @@ optimization. Re-pushing an unchanged card spends a credit to change nothing.
 `--force` overrides it; use it when a card was edited or deleted on the
 DeepVista side and needs re-establishing.
 
-`record` writes `card_id`, `synced_at`, and the content hash back onto the
-entity file, which is what makes the next run's `skip` decision possible. **If
-record is skipped, the next run creates a duplicate card** — the entity has no
-memory of having been pushed.
+The applied push writes `card_id`, `synced_at`, and the content hash back onto
+the entity file after each successful call. `record` remains a manual recovery
+command for a card created before local write-back completed.
 
 ## Card shape
 
@@ -239,8 +216,7 @@ uv run scripts/deepvista_cards.py compare 2026-W35 --repo . --against deepvista-
 ### How `fetch` reads headlessly
 
 `fetch` spawns `npx -y mcp-remote <endpoint>` itself and speaks JSON-RPC to it
-over stdio — the same proxy the `.mcp.json` entry names, started by the script
-rather than by the host app. That works without a human because the proxy
+over stdio. That works without a human because the proxy
 caches its OAuth token under `~/.mcp-auth` after one browser sign-in; from then
 on any process that starts it gets a session. Three things learned making it
 run:
@@ -255,7 +231,7 @@ run:
   was built on had npm 6's `npx` first on PATH and npm 11's under Homebrew.
   `fetch` resolves an `npx` of version 7+ across PATH and the well-known install
   locations for its *own* subprocess — that path is never written into a repo
-  file, so it can be machine-specific in a way `.mcp.json` cannot.
+  file, so it can be machine-specific without creating ambient configuration.
 - **A session can go missing between `initialize` and the first call.** The
   client re-initializes once on the same proxy before giving up, and the output
   records `session_reinits` so a run that needed it is distinguishable from one
@@ -298,139 +274,21 @@ dropped, add the entity's material to the local summary rather than replacing
 prose wholesale — the local file is the one under version control and the one
 the scrub policy has been applied to.
 
-## Test run — the procedure for the first live push
+## First applied run
 
-Nothing below this line has been exercised. Run it in order and stop at the
-first surprise; the point is to find out where the inferred contract is wrong,
-not to get cards in.
+Run the sequence in order and stop at the first surprise:
 
-**1. Register the server** — from the skill, so the requirement travels with the
-code that has it rather than being re-derived per repo:
+1. `doctor` checks the local runtime and performs an explicit endpoint probe.
+2. `plan --limit 1 --show-body` renders one complete card locally.
+3. `push --limit 1` previews the exact write locally and says that no call ran.
+4. `push --limit 1 --apply` starts the proxy, completes OAuth if needed, writes
+   one card, and records its id.
+5. Re-run `plan --include-skipped`; the entity must now say `skip`.
+6. Only then apply the rest, optionally one category at a time.
 
-```bash
-uv run <skill>/scripts/deepvista_cards.py install-mcp --repo .
-```
-
-Idempotent, refuses to overwrite a conflicting entry, and writes **no
-credentials** — the server does OAuth 2.1 with dynamic client registration, so
-the entry is a name, a transport and a URL. `--scope user` instead prints the
-vendor's own one-liner, which registers once for every repo on the machine:
-
-```bash
-claude mcp add --transport http deepvista-server https://api.deepvista.ai/mcp
-```
-
-**2. Authenticate — and this is the step to plan around, not discover.**
-
-**There is no headless path today.** Every client the vendor documents ends in a
-browser OAuth flow: Cursor restarts and runs *MCP: Connect to server*, Claude
-Desktop quits and reopens, Claude Code runs `/mcp`. The docs also list API-key
-auth — `Authorization: Bearer <key>` from *Settings → Security & Access* — which
-would be headless, but **that setting is not exposed in the product yet**
-(checked 2026-09-01). Until it is, OAuth is the only route.
-
-**Which config you choose decides who runs the OAuth, and that is the whole
-question.** `type: http` hands it to the host app's MCP client — needs nothing
-installed, but the app must expose a connect flow you can reach. The
-`mcp-remote` form runs a local stdio proxy that does the OAuth **itself** and
-caches the token under `~/.mcp-auth`, so one browser sign-in makes every later
-session headless, agent runs included — at the cost of a **Node 18+**
-dependency, since `npx` runs the proxy.
-
-`install-mcp` **chooses between them against the runtime that is actually
-present** (`--transport auto`, the default), and `--transport mcp-remote|http`
-overrides it. Prefer the proxy where Node can run it; the http form is a genuine
-fallback rather than a downgrade, because DeepVista serves the discovery
-metadata a native MCP client needs — verified live 2026-09-01:
-
-| Probe | Result |
-|---|---|
-| `POST /mcp` unauthenticated | `401` + `WWW-Authenticate: Bearer resource_metadata=…` (RFC 9728) |
-| Protected-resource metadata | `resource: https://api.deepvista.ai/mcp`, auth server `…supabase.co/auth/v1` |
-| Authorization-server metadata | authorize + token + **`registration_endpoint`** (dynamic client registration), PKCE `S256` |
-
-So the sequence is:
-
-1. **Node 18+ only if you take the proxy form** — `npx` runs it, and nothing
-   works without it. This is a *conditional* prerequisite, not an absolute one;
-2. a **fresh** session, because MCP servers connect at start-up and one added to
-   `.mcp.json` mid-session is invisible to that session;
-3. the first launch opens a browser once. After that the cached token carries.
-
-**Check it before the session start-up does**, which is the step whose absence
-caused the 2026-09-01 break — `install-mcp` wrote an `npx` entry onto a machine
-with no Node, reported success, and the failure appeared a session later as
-`deepvista (ENOENT): Executable not found in $PATH: npx`, naming neither the
-file nor the command responsible:
-
-```bash
-uv run <skill>/scripts/deepvista_cards.py doctor --repo .
-```
-
-It reports the runtime, the registered entry and the endpoint separately, exits
-non-zero when the registration cannot work as written, and — for the exact
-ENOENT case — prints the start-up error it is predicting, so the two are
-recognisable as one problem.
-
-An agent run can do everything up to the handoff — `install-mcp`, then `plan`,
-which renders every card — and nothing past it. Plan for a human at step 2 rather
-than discovering it there.
-
-Do not reach for `deepvista auth login` to shortcut this; see the gotcha below.
-
-**3. Dump the tool list before pushing anything.**
-
-This step is not optional and the vendor docs are why. As of 2026-09-01 they
-publish the setup command and the auth model and **nothing else** — no tool
-names, no parameters, no `card_type` enum, no `status` field. The linked
-OpenAPI specification is still Mintlify's stock plant-store example. So every
-field this bridge sends is inferred from the CLI's REST calls and none of it is
-confirmed against a served contract.
-
-Ask for the DeepVista MCP tool list verbatim and reconcile it against what this
-bridge emits. The card fields here — `card_type`, `title`, `description`,
-`tags`, `status` — were read off the CLI's REST calls, **not off a connected
-server**, so this is the step most likely to find a mismatch. Two things to check
-specifically:
-
-- Is there a `status` parameter at all? If the MCP tool does not expose it,
-  cards will land `unconfirmed` and search will not surface them — which changes
-  the plan from "push everything" to "push, then confirm in the UI".
-- Does `card_type` accept the value being sent (`note`, `topic`, `keypoint`,
-  `person`, `organization`)?
-
-**4. Plan exactly one card.**
-
-```bash
-uv run .claude/skills/catchup/scripts/deepvista_cards.py plan --repo . --week 2026-W35 --limit 1 --show-body
-```
-
-Read the markdown body before it goes anywhere.
-
-**5. Push that one**, by calling the MCP create tool with the `card` object.
-
-**6. Check three things in the product**, in this order:
-
-| Check | Why it matters |
-|---|---|
-| The card renders — timeline and all | The body is markdown; if it lands as a wall of text the format is wrong |
-| **It is findable by search** | This is the `confirmed` test. If it does not appear, step 3's status question was the answer |
-| Credit balance moved by how much | The free tier is 100/month; 25 entities at an unknown per-card cost is the actual budget question |
-
-**7. Record the id and prove the skip works.**
-
-```bash
-uv run .claude/skills/catchup/scripts/deepvista_cards.py record --repo . --id <entity-id> --card-id <returned-id>
-uv run .claude/skills/catchup/scripts/deepvista_cards.py plan --repo . --week 2026-W35 --include-skipped
-```
-
-That entity must now say `skip`. If it says `create`, the write-back did not
-take and a full run would duplicate every card.
-
-**8. Only then** push the rest — and consider `--category meeting` first, since
-those entities are the ones whose value compounds.
-
-**What to report back:** the tool list, which step surprised you, the credit
-delta for one card, and whether search found it.
+The first applied run is where to verify rendering, search visibility, and
+credit cost. The served tool contract was reconciled on 2026-09-01; a future
+schema mismatch should fail loudly before local write-back rather than be
+papered over with a host-level MCP registration.
 
 ---

--- a/.claude/skills/catchup/reference/portability.md
+++ b/.claude/skills/catchup/reference/portability.md
@@ -87,9 +87,10 @@ So that it runs the same under either runtime:
 - **The slash command is a convenience, not the interface.** `/catchup` is a
   Claude Code affordance; a runtime without slash commands invokes the skill by
   name or follows `SKILL.md` directly. Nothing in the workflow requires it.
-- **One optional runtime dependency, declared:** the DeepVista sync calls MCP
-  tools, which the *model* calls, not the scripts. `plan` and `record` stay
-  deterministic and shell-runnable either way, and the sync is off by default.
+- **One optional runtime dependency, command-scoped:** the DeepVista bridge
+  starts its pinned MCP proxy only for explicit `push --apply` and `fetch`
+  commands. `plan`, dry `push`, `record`, and `compare` stay local, and the sync
+  is off by default. No host-level MCP registration is required or supported.
 - **Config, not code, carries repo specifics** — so a repo needs no per-runtime
   variant of the skill itself.
 

--- a/.claude/skills/catchup/scripts/deepvista_cards.py
+++ b/.claude/skills/catchup/scripts/deepvista_cards.py
@@ -12,17 +12,17 @@ within a context card." So the mapping is one entity to one card -- not one card
 per week and not one per bullet. A thread running four weeks stays ONE card that
 accumulates, which is the same thing the entity store does locally.
 
-Transport is the hosted MCP server at https://api.deepvista.ai/mcp. MCP tools are
-called by the model, not by a shell script, so this script does the half a script
-can do deterministically: decide create vs update vs skip, render the card body,
-and record the returned card id. The model makes the actual tool calls in between.
+Transport is the hosted MCP server at https://api.deepvista.ai/mcp. This script
+owns a short-lived MCP proxy only for explicit `push --apply` and `fetch`
+commands. DeepVista must not be registered in a repo- or user-scoped MCP config:
+those registrations are started by the host for every session, including work
+that has nothing to do with catchup.
 
-    plan  ->  [model calls the deepvista MCP tools]  ->  record
+    plan  ->  inspect  ->  push --apply
 
-Reading back is the exception: once the mcp-remote proxy has cached a sign-in,
-`fetch` spawns it and reads the week's cards headlessly, into a file the
-aggregator's control (and `compare`) can run on. Reads are free and change
-nothing, which is why that half is scripted and the push half is not.
+Once the mcp-remote proxy has cached a sign-in, `push --apply` and `fetch` spawn
+it headlessly for the duration of that command. `push` without `--apply` is a
+local preview and makes no network call.
 
     fetch --week W --out cards.json  ->  [a summary written from the cards]  ->  compare
 
@@ -32,9 +32,11 @@ content hash and emits `skip` for anything unchanged.
 
 Usage:
     deepvista_cards.py plan --week 2026-W35
+    deepvista_cards.py push --week 2026-W35             # local preview
+    deepvista_cards.py push --week 2026-W35 --apply     # explicit MCP write
     deepvista_cards.py plan --all --category meeting
     deepvista_cards.py plan --week 2026-W35 --show-body    # eyeball the markdown
-    deepvista_cards.py record --id ray-summit --card-id abc-123
+    deepvista_cards.py record --id ray-summit --card-id abc-123  # recovery only
 """
 
 import argparse
@@ -52,140 +54,27 @@ from entities import (  # noqa: E402
     load_all, load_config, store_dir, utc_now, write_entity,
 )
 
-# The server this bridge needs, declared ONCE and travelling with the skill.
-# Registration used to be per-repo prose in the runbook, which meant every repo
-# adopting the sync re-derived the same three values by hand and could get any of
-# them wrong. `install-mcp` writes this into a target repo's .mcp.json, so the
-# requirement lives with the code that has the requirement.
-#
-# There are two ways to register it, and it matters which one you pick:
-#
-#   type:http    -- the HOST APP's MCP client runs the OAuth. Needs nothing
-#                   installed, but the app must expose a connect flow you can
-#                   reach; a dead end where it does not.
-#   mcp-remote   -- a local stdio proxy runs the OAuth ITSELF and caches the
-#                   token under ~/.mcp-auth. One browser sign-in on first launch,
-#                   headless from then on, INCLUDING from agent sessions. Costs a
-#                   hard Node 18+ dependency, because `npx` runs the proxy.
-#
-# The proxy is preferred WHEN IT CAN RUN, because it makes the push reachable
-# without a human in the loop after the first time. It was previously the only
-# form this script would write, unconditionally -- and that is the bug fixed on
-# 2026-09-01: `install-mcp` wrote an `npx` entry onto a machine with no Node at
-# all, cheerfully reported success, and the failure surfaced one session later as
-# `deepvista (ENOENT): Executable not found in $PATH: npx` at start-up, far from
-# the command that caused it. A precondition a tool never checks is a precondition
-# its user discovers at the worst moment.
-#
-# So: the entry is chosen against the runtime that is actually present. The http
-# form is the fallback rather than a downgrade -- DeepVista serves the RFC 9728
-# protected-resource metadata and RFC 8414 authorization-server metadata (with
-# dynamic client registration) that a native MCP client needs, verified against
-# the live endpoint 2026-09-01. What it costs is the headless property: the host
-# app owns the token, so re-auth happens on the app's terms, not `~/.mcp-auth`'s.
-MCP_SERVER_NAME = "deepvista"
+# The endpoint and pinned proxy travel with the command that uses them. Keeping
+# them out of .mcp.json is deliberate: host applications eagerly start registered
+# servers at session creation, before a model has chosen a tool.
 MCP_ENDPOINT = "https://api.deepvista.ai/mcp"
 # The proxy is PINNED. `npx -y mcp-remote` resolves to whatever npm published
 # last, and this script hands that code a cached OAuth token and reads private
 # card bodies through it -- an unpinned package there is a supply-chain hole
 # with a login attached. Bump deliberately, in one place, after reading the
-# release; `install-mcp --force` re-pins an entry that predates the pin.
+# release; every explicit push/fetch uses this exact version.
 MCP_REMOTE_PKG = "mcp-remote@0.8.3"
-MCP_ENTRY_PROXY = {"command": "npx", "args": ["-y", MCP_REMOTE_PKG, MCP_ENDPOINT]}
 # npm 6's npx cannot run the proxy entry: it does not understand `-y`.
 MCP_MIN_NPX = 7
-MCP_ENTRY_HTTP = {"type": "http", "url": MCP_ENDPOINT}
-MCP_ENTRIES = {"mcp-remote": MCP_ENTRY_PROXY, "http": MCP_ENTRY_HTTP}
-MCP_RELPATH = ".mcp.json"
-
-
-def entry_form(entry):
-    """Which transport an .mcp.json entry is, ignoring the proxy's pin.
-
-    An exact match against MCP_ENTRIES is too strict once the proxy package is
-    pinned: a repo carrying the pre-pin `mcp-remote` entry is the SAME form at a
-    different version, not a different transport, and should be told to re-pin
-    rather than that it conflicts.
-    """
-    if not isinstance(entry, dict):
-        return None
-    if entry.get("type") == "http" and entry.get("url") == MCP_ENDPOINT:
-        return "http"
-    args = entry.get("args") or []
-    if (entry.get("command") == "npx" and MCP_ENDPOINT in args
-            and any(str(a).split("@")[0] == "mcp-remote" for a in args)):
-        return "mcp-remote"
-    return None
 MCP_MIN_NODE = 18
-
-
-def node_runtime():
-    """What Node is actually on PATH, as (npx_path, major, label).
-
-    `npx` is what the entry names, so `npx` is what gets probed -- not `node`.
-    A Node install missing npx, or an npx too old to run the proxy, is exactly
-    the case a `node --version` check would wave through.
-    """
-    npx = shutil.which("npx")
-    if not npx:
-        return None, None, "no `npx` on PATH"
-    node = shutil.which("node")
-    if not node:
-        return npx, None, "`npx` found but no `node` on PATH"
-    try:
-        out = subprocess.run([node, "--version"], capture_output=True, text=True,
-                             timeout=20)
-    except (OSError, subprocess.SubprocessError) as exc:
-        return npx, None, f"`node --version` failed ({exc})"
-    m = re.match(r"v(\d+)\.", (out.stdout or "").strip())
-    if not m:
-        return npx, None, f"could not parse `node --version` ({(out.stdout or '').strip()!r})"
-    major = int(m.group(1))
-    if major < MCP_MIN_NODE:
-        return npx, major, f"Node {major} is older than the required {MCP_MIN_NODE}+"
-
-    # And the npx version, which is a SEPARATE question from Node's. A machine
-    # can carry a current node beside an npm 6 npx -- npm 6's npx does not
-    # understand `-y`, so it reads the rest of the line as packages and tries to
-    # npm-install the server URL. npm fetches it, gets the OAuth challenge every
-    # MCP server answers with, and reports `E401 Unable to authenticate`: an auth
-    # error, on a connector whose auth you are setting up, pointing at the wrong
-    # layer entirely. Probing npx by PRESENCE and node by VERSION waves exactly
-    # this through, which is the case this function set out to catch.
-    try:
-        nv = subprocess.run([npx, "--version"], capture_output=True, text=True,
-                            timeout=20)
-        nver = (nv.stdout or "").strip()
-        nmaj = int(nver.split(".")[0])
-    except (OSError, subprocess.SubprocessError, ValueError, IndexError):
-        return npx, major, f"Node v{major} at {node} (could not read `npx --version`)"
-    if nmaj < MCP_MIN_NPX:
-        alt = ""
-        for cand in ("/opt/homebrew/bin/npx", "/usr/local/bin/npx"):
-            if cand == npx or not os.path.isfile(cand):
-                continue
-            try:
-                av = subprocess.run([cand, "--version"], capture_output=True,
-                                    text=True, timeout=20).stdout.strip()
-                if int(av.split(".")[0]) >= MCP_MIN_NPX:
-                    alt = f"; npx {av} at {cand} would work but loses on PATH"
-                    break
-            except (OSError, subprocess.SubprocessError, ValueError, IndexError):
-                continue
-        return npx, None, (f"npx {nver} is older than the required {MCP_MIN_NPX}+ "
-                           f"and cannot run this entry{alt}")
-    return npx, major, f"Node v{major} at {node}, npx {nver}"
 
 
 def resolve_npx(explicit=None):
     """An npx that can run the proxy, or None -- looking past PATH's first hit.
 
-    `node_runtime()` answers "will the entry in .mcp.json start", which is a
-    PATH question because the host app resolves the bare `npx` it names. This
-    answers a different one: "can THIS script start the proxy itself" -- and for
-    that the well-known install locations are fair game, because the path is
-    used here and never written into a repo file. A Homebrew npx 11 sitting
-    behind an npm-6 npx on PATH is exactly the machine this was written on.
+    Unlike a host registration, this command may look past PATH for a usable
+    runtime. The resolved path is used only by the short-lived subprocess and
+    is never written into repository or user configuration.
     """
     cands = [explicit] if explicit else []
     cands += [shutil.which("npx"), "/opt/homebrew/bin/npx", "/usr/local/bin/npx"]
@@ -205,15 +94,14 @@ def resolve_npx(explicit=None):
 
 
 class McpClient:
-    """The smallest MCP client that can read cards: JSON-RPC over the proxy's stdio.
+    """The smallest MCP client that can read or write cards over proxy stdio.
 
     This exists because "MCP tools are called by the model, not by a script" was
     true only until the proxy cached a token. Once `mcp-remote` has signed in
     once, it will start headless for anyone who spawns it -- an agent session or
     a shell script alike -- and a READ of the week's cards is then a deterministic
-    thing a script can own, the same way `plan` and `record` already are. Writes
-    stay with the model on purpose: they spend credits and change the product,
-    and a script that pushes on its own is a script that pushes twice.
+    thing an explicit catchup command can own. Writes happen only through
+    `push --apply`; previewing a push never constructs this client.
 
     If the proxy needs a sign-in it prints the authorization URL to stderr and
     waits. That is surfaced rather than hidden, because the fix is a human in a
@@ -397,15 +285,6 @@ class McpClient:
                 pass
         self.proc = None
 
-
-def choose_transport(pref):
-    """Resolve --transport into (key, entry, why). `auto` follows the runtime."""
-    if pref in MCP_ENTRIES:
-        return pref, MCP_ENTRIES[pref], f"--transport {pref}"
-    npx, major, label = node_runtime()
-    if npx and major and major >= MCP_MIN_NODE:
-        return "mcp-remote", MCP_ENTRY_PROXY, label
-    return "http", MCP_ENTRY_HTTP, label
 
 # Entity type -> DeepVista card_type. The right-hand side is DeepVista's fixed
 # vocabulary (from the CLI's CARD_TYPES), not ours, so the mapping is lossy on
@@ -609,175 +488,17 @@ def build_tags(e, cfg, repo_label, all_entities=()):
     return sorted(t for t in tags if t)
 
 
-def cmd_install_mcp(args, repo, cfg, sdir):
-    """Register the DeepVista server in a repo's .mcp.json, idempotently.
-
-    NO CREDENTIALS ARE WRITTEN and none belong here: the server does OAuth 2.1
-    with dynamic client registration, so the entry is a name, a transport and a
-    URL, and the browser sign-in happens once per machine through `/mcp`. A repo
-    file is never the place for a bearer token even where a server accepts one.
-
-    Project scope by default because that is what makes the skill portable -- the
-    repo that runs the sync carries its own declaration. `--scope user` prints
-    the one-line command instead, for someone who would rather authenticate once
-    for every repo; a user-scope registration is a machine setting and not
-    something a repo-level tool should write on anyone's behalf.
-
-    The transport is CHOSEN, not assumed -- see the MCP_ENTRIES comment. `auto`
-    writes the proxy form where Node 18+ can run it and the http form where it
-    cannot, so the entry that lands is one this machine can actually start.
-    """
-    key, entry, why = choose_transport(args.transport)
-
-    if args.scope == "user":
-        cmd = (f"claude mcp add {MCP_SERVER_NAME} -- npx -y {MCP_REMOTE_PKG} {MCP_ENDPOINT}"
-               if key == "mcp-remote" else
-               f"claude mcp add --transport http {MCP_SERVER_NAME} {MCP_ENDPOINT}")
-        print(f"Transport: {key} ({why})\n")
-        print("Run this once, in an interactive terminal:\n")
-        print(f"  {cmd}\n")
-        print("User scope covers every repo on this machine; project scope (the")
-        print("default here) keeps the declaration with the repo that uses it.")
-        print("Either way the first launch opens a browser once.")
-        return
-
-    path = os.path.join(repo, MCP_RELPATH)
-    blob = {}
-    if os.path.isfile(path):
-        try:
-            with open(path) as fh:
-                blob = json.load(fh)
-        except json.JSONDecodeError as e:
-            die(f"{MCP_RELPATH} is not valid JSON ({e}) -- refusing to overwrite it")
-    servers = blob.setdefault("mcpServers", {})
-    existing = servers.get(MCP_SERVER_NAME)
-
-    # flush: `die` writes to stderr, and block-buffered stdout would otherwise
-    # report the transport AFTER the error explaining it.
-    print(f"Transport: {key} ({why})", flush=True)
-
-    if existing == entry:
-        print(f"already registered: {MCP_SERVER_NAME} -> {MCP_ENDPOINT}")
-    elif existing and not args.force:
-        # Naming the OTHER known form explicitly, because the overwhelmingly
-        # common case for this branch is a repo carrying the entry for a
-        # transport this machine cannot run -- which is a one-flag fix, not a
-        # mystery worth reading the source over.
-        other = entry_form(existing)
-        if other == key == "mcp-remote":
-            hint = (f"\nSame proxy form, different package pin -- this skill pins "
-                    f"{MCP_REMOTE_PKG}.\nRe-run with --force to re-pin it.")
-        elif other and other != key:
-            hint = (f"\nThat is the {other} form and this machine resolved to {key}."
-                    f"\nRe-run with --force to switch it, or --transport {other} to keep it.")
-        else:
-            hint = "\nLeaving it alone -- pass --force to replace it."
-        die(f"{MCP_SERVER_NAME} is already in {MCP_RELPATH} with different settings:\n"
-            f"  {json.dumps(existing)}\n"
-            f"expected:\n  {json.dumps(entry)}" + hint)
-    else:
-        servers[MCP_SERVER_NAME] = dict(entry)
-        if args.dry_run:
-            print(f"would write to {os.path.relpath(path, repo)}:")
-            print(json.dumps({MCP_SERVER_NAME: entry}, indent=2))
-            return
-        with open(path, "w") as fh:
-            json.dump(blob, fh, indent=2)
-            fh.write("\n")
-        print(f"registered {MCP_SERVER_NAME} in {os.path.relpath(path, repo)}")
-
-    if key == "mcp-remote":
-        print("\nNeeds Node 18+ on the PATH the MCP CLIENT sees -- `npx` runs the proxy.")
-        print("The first launch opens a browser once; the proxy caches the token under")
-        print("~/.mcp-auth and every session after that is headless, agent runs included.")
-    else:
-        print("\nNo Node needed: the host app's own MCP client runs the OAuth. In Claude")
-        print("Code that is `/mcp` -> authenticate, which needs an INTERACTIVE session.")
-        print("Install Node 18+ and re-run with --force for the headless-after-first-run")
-        print("proxy form instead.")
-
-    print("\nStart a FRESH session either way: MCP servers connect at start-up, so one")
-    print("added mid-session is invisible to it. Verify with `doctor` before pushing.")
-    print("\nThen dump the tool list before pushing anything: the vendor publishes the")
-    print("setup and the auth model but not the tool names, parameters, card_type")
-    print("values or status field, so every field this bridge sends is inferred.")
-
-
 def cmd_doctor(args, repo, cfg, sdir):
-    """Diagnose the registration BEFORE a session start-up failure does.
-
-    This exists because the original failure mode was silent at the only moment
-    anyone could have acted on it. `install-mcp` wrote an `npx` entry, printed
-    success, and the machine had no Node; the first evidence was a start-up line
-    in the NEXT session -- `ENOENT: Executable not found in $PATH: npx` -- which
-    names neither the file that asked for npx nor the command that put it there.
-
-    So `doctor` checks the three things that are separately capable of breaking
-    it, and reports each one on its own: the runtime, the registered entry, and
-    the endpoint. It is read-only and exits non-zero when the registration
-    cannot work as written, which makes it usable as a preflight.
-    """
+    """Check the command-owned proxy runtime and endpoint."""
     ok = True
 
     print("== runtime ==")
-    npx, major, label = node_runtime()
-    proxy_ok = bool(npx and major and major >= MCP_MIN_NODE)
-    print(f"  {'OK  ' if proxy_ok else 'note'}  {label}")
+    npx = resolve_npx(args.npx)
     if npx:
-        print(f"        npx: {npx}")
-    if not proxy_ok:
-        print(f"        -> the mcp-remote proxy form CANNOT run here (needs Node {MCP_MIN_NODE}+).")
-        print("        -> `brew install node`, or use --transport http.")
-
-    print("\n== registration ==")
-    path = os.path.join(repo, MCP_RELPATH)
-    if not os.path.isfile(path):
-        print(f"  FAIL  no {MCP_RELPATH} in {repo}")
-        print(f"        -> run: install-mcp --repo {repo}")
-        ok = False
+        print(f"  OK    command-owned proxy can run with {npx}")
     else:
-        try:
-            blob = json.load(open(path))
-        except json.JSONDecodeError as e:
-            print(f"  FAIL  {MCP_RELPATH} is not valid JSON ({e})")
-            return 1
-        entry = (blob.get("mcpServers") or {}).get(MCP_SERVER_NAME)
-        if not entry:
-            print(f"  FAIL  {MCP_SERVER_NAME} is not registered in {MCP_RELPATH}")
-            print(f"        -> run: install-mcp --repo {repo}")
-            ok = False
-        else:
-            key = entry_form(entry)
-            print(f"  OK    {MCP_SERVER_NAME} -> {json.dumps(entry)}")
-            if key == "mcp-remote" and entry != MCP_ENTRY_PROXY:
-                print(f"  note  the proxy is not pinned to {MCP_REMOTE_PKG}; the host app will")
-                print("        run whatever npm publishes next, with the cached sign-in.")
-                print(f"        -> install-mcp --repo {repo} --force   (re-pins it)")
-            if key is None:
-                print("  note  that is neither known form; it may still be valid, but this")
-                print("        script cannot vouch for it.")
-            elif key == "mcp-remote" and not proxy_ok:
-                # Say it in the words the failure will actually use, so the two
-                # are recognisably the same problem -- which means predicting the
-                # RIGHT one. A missing npx and an npx too old fail at different
-                # moments with different messages, and naming the wrong symptom
-                # sends the reader to the wrong layer just as surely as no
-                # diagnosis at all.
-                if shutil.which("npx"):
-                    print("  FAIL  this entry runs `npx -y`, which the `npx` on this PATH")
-                    print("        is too old to understand. It will read the URL as a")
-                    print("        package and try to install it, failing with:")
-                    print("          npm ERR! code E401")
-                    print("          npm ERR! Unable to authenticate, need: Bearer resource_metadata=...")
-                    print("        That is npm's auth error, not the connector's — the proxy")
-                    print("        never starts.")
-                else:
-                    print("  FAIL  this entry runs `npx`, which this machine cannot resolve.")
-                    print("        Every session will fail at start-up with:")
-                    print("          deepvista (ENOENT): Executable not found in $PATH: npx")
-                print(f"        -> `brew install node` (then restart the session), or")
-                print(f"        -> install-mcp --repo {repo} --transport http --force")
-                ok = False
+        print(f"  FAIL  no npx {MCP_MIN_NPX}+ found; install Node {MCP_MIN_NODE}+")
+        ok = False
 
     print("\n== endpoint ==")
     import urllib.error
@@ -813,7 +534,7 @@ def cmd_doctor(args, repo, cfg, sdir):
     return 0 if ok else 1
 
 
-def cmd_plan(args, repo, cfg, sdir):
+def build_plan(args, repo, cfg, sdir):
     ents = load_all(sdir)
     # Contact state is derived from the meeting entities, so derivation must see
     # ALL of them -- a --week or --category filter would otherwise hide the very
@@ -919,7 +640,7 @@ def cmd_plan(args, repo, cfg, sdir):
             break
 
     ready = args.show_body
-    print(json.dumps({
+    return {
         "endpoint": MCP_ENDPOINT,
         "limited_to": args.limit or None,
         "repo": repo_label,
@@ -930,12 +651,97 @@ def cmd_plan(args, repo, cfg, sdir):
         "pushable": ready,
         "plan": plan,
         "next": (
-            "For each item call the DeepVista MCP create/update card tool with `card`, "
-            "then run: deepvista_cards.py record --id <entity_id> --card-id <returned id>"
+            "Review this payload, then run `deepvista_cards.py push` with the same "
+            "selection and `--apply`; the command will write and record card ids."
             if ready else
             "PREVIEW ONLY — `card` here has no `description`, so it is not a payload. "
             "Re-run with --show-body to get the full card bodies before pushing anything."),
-    }, indent=2))
+    }
+
+
+def cmd_plan(args, repo, cfg, sdir):
+    print(json.dumps(build_plan(args, repo, cfg, sdir), indent=2))
+
+
+def _returned_card_id(result):
+    if not isinstance(result, dict):
+        return None
+    for key in ("id", "card_id"):
+        if result.get(key):
+            return result[key]
+    for key in ("card", "context_card"):
+        nested = result.get(key)
+        if isinstance(nested, dict):
+            for id_key in ("id", "card_id"):
+                if nested.get(id_key):
+                    return nested[id_key]
+    return None
+
+
+def _record_card_id(sdir, entity_id, card_id):
+    p = entity_path(sdir, entity_id)
+    if not os.path.isfile(p):
+        die(f"no such entity: {entity_id}")
+    with open(p) as fh:
+        e = json.load(fh)
+    e.setdefault("deepvista", {})
+    e["deepvista"]["card_id"] = card_id
+    e["deepvista"]["synced_at"] = utc_now()
+    e["deepvista"]["content_hash"] = content_hash(e)
+    write_entity(sdir, e)
+    return e["deepvista"]
+
+
+def cmd_push(args, repo, cfg, sdir):
+    """Explicitly write planned cards through one short-lived MCP proxy."""
+    dv_cfg = cfg.get("deepvista") or {}
+    if not dv_cfg.get("enabled") and not args.force:
+        die("deepvista.enabled is not true in this repo's config; pass --force to push anyway")
+
+    # The preview path is deliberately local-only. Merely asking what would be
+    # pushed must not authenticate, contact the endpoint, or spend a credit.
+    plan_args = argparse.Namespace(**vars(args))
+    plan_args.show_body = True
+    plan_args.include_skipped = False
+    result = build_plan(plan_args, repo, cfg, sdir)
+    if not args.apply:
+        result["applied"] = False
+        result["next"] = "No DeepVista call was made. Re-run `push` with --apply to write this plan."
+        print(json.dumps(result, indent=2))
+        return
+    if not result["plan"]:
+        print(json.dumps({"applied": True, "count": 0, "cards": [],
+                          "network_called": False}, indent=2))
+        return
+
+    npx = resolve_npx(args.npx)
+    if not npx:
+        die(f"no npx {MCP_MIN_NPX}+ found to run the mcp-remote proxy -- `brew install node`, "
+            "or pass --npx /path/to/npx")
+    client = McpClient(npx, timeout=args.timeout)
+    applied = []
+    try:
+        for item in result["plan"]:
+            response = client.call(
+                "upsert_context_card",
+                card_id=item["card_id"],
+                properties=item["card"],
+                related_context_card_ids=item["related_card_ids"],
+            )
+            if isinstance(response, dict) and response.get("_error"):
+                die(f"upsert_context_card for {item['entity_id']}: {response['_error']}")
+            card_id = _returned_card_id(response)
+            if not card_id:
+                die(f"upsert_context_card for {item['entity_id']} returned no card id: "
+                    f"{json.dumps(response)[:400]}")
+            state = _record_card_id(sdir, item["entity_id"], card_id)
+            applied.append({"entity_id": item["entity_id"], "action": item["action"],
+                            "card_id": card_id, "synced_at": state["synced_at"]})
+    finally:
+        client.close()
+    print(json.dumps({"applied": True, "count": len(applied), "cards": applied,
+                      "session": {"handshake_attempts": client.attempts,
+                                  "reinits": client.reinits}}, indent=2))
 
 
 def _mentions(text, entity, week=None):
@@ -1095,8 +901,7 @@ def cmd_fetch(args, repo, cfg, sdir):
 
     That file is what the aggregator's control is built on: a second summary of
     the same week, written from the cards alone and diffed against the local one
-    with `compare`. A read costs no credits and changes nothing, which is why
-    this half is scripted and the push half is not.
+    with `compare`. A read costs no credits and changes nothing.
     """
     ents = load_all(sdir)
     all_ents = list(ents)
@@ -1221,20 +1026,10 @@ def cmd_fetch(args, repo, cfg, sdir):
 
 
 def cmd_record(args, repo, cfg, sdir):
-    p = entity_path(sdir, args.id)
-    if not os.path.isfile(p):
-        die(f"no such entity: {args.id}")
-    with open(p) as fh:
-        e = json.load(fh)
-    e.setdefault("deepvista", {})
-    e["deepvista"]["card_id"] = args.card_id
-    e["deepvista"]["synced_at"] = utc_now()
-    # Hash the entity WITHOUT the deepvista block, matching plan's comparison.
-    e["deepvista"]["content_hash"] = content_hash(e)
-    write_entity(sdir, e)
+    state = _record_card_id(sdir, args.id, args.card_id)
     print(json.dumps({"id": args.id, "card_id": args.card_id,
-                      "content_hash": e["deepvista"]["content_hash"],
-                      "synced_at": e["deepvista"]["synced_at"]}, indent=2))
+                      "content_hash": state["content_hash"],
+                      "synced_at": state["synced_at"]}, indent=2))
 
 
 def main():
@@ -1257,19 +1052,9 @@ def main():
                    help="plan at most N items — use --limit 1 for a first live push")
     p.set_defaults(fn=cmd_plan)
 
-    p = sub.add_parser("install-mcp", parents=[common],
-                       help="register the DeepVista MCP server in this repo's .mcp.json")
-    p.add_argument("--scope", choices=["project", "user"], default="project",
-                   help="project writes .mcp.json; user prints the one-line command")
-    p.add_argument("--dry-run", action="store_true")
-    p.add_argument("--force", action="store_true", help="replace a conflicting entry")
-    p.add_argument("--transport", choices=["auto", "mcp-remote", "http"], default="auto",
-                   help="auto (default) picks mcp-remote where Node 18+ can run it, "
-                        "else the http form the host app authenticates itself")
-    p.set_defaults(fn=cmd_install_mcp)
-
     p = sub.add_parser("doctor", parents=[common],
-                       help="check the runtime, the registered entry and the endpoint")
+                       help="check the command-owned proxy runtime and endpoint")
+    p.add_argument("--npx", default=None, help="npx to run the mcp-remote proxy with")
     p.set_defaults(fn=cmd_doctor)
 
     p = sub.add_parser("compare", parents=[common],
@@ -1290,6 +1075,19 @@ def main():
     p.add_argument("--timeout", type=int, default=90, help="seconds to wait per call")
     p.add_argument("--force", action="store_true", help="read even if deepvista.enabled is false")
     p.set_defaults(fn=cmd_fetch)
+
+    p = sub.add_parser("push", parents=[common],
+                       help="preview or explicitly push cards through a short-lived MCP proxy")
+    p.add_argument("--week")
+    p.add_argument("--all", action="store_true")
+    p.add_argument("--category", choices=CATEGORY_ORDER)
+    p.add_argument("--status")
+    p.add_argument("--limit", type=int, default=0)
+    p.add_argument("--force", action="store_true", help="re-push unchanged cards or override disabled config")
+    p.add_argument("--apply", action="store_true", help="make the DeepVista calls; omitted means local preview")
+    p.add_argument("--npx", default=None, help="npx to run the mcp-remote proxy with")
+    p.add_argument("--timeout", type=int, default=90, help="seconds to wait per call")
+    p.set_defaults(fn=cmd_push)
 
     p = sub.add_parser("record", parents=[common], help="write back the card id after an MCP call")
     p.add_argument("--id", required=True)

--- a/.claude/skills/catchup/scripts/deploy.py
+++ b/.claude/skills/catchup/scripts/deploy.py
@@ -52,7 +52,7 @@ SELF_NAME = os.path.basename(SCRIPT)
 # whole class of bug this script exists for gets reintroduced. The two copies of
 # THIS file are kept identical by hand; `diff` them when either changes.
 SKILL_NAME = os.path.basename(SRC_SKILL)
-PARTS = ["SKILL.md", "assets", "reference", "scripts"]
+PARTS = ["SKILL.md", "assets", "reference", "scripts", "tests"]
 # The slash-command file travels with the skill when the source has one. It
 # lives outside the skill directory, so it is compared on its own.
 COMMAND_REL = os.path.join(".claude", "commands", f"{SKILL_NAME}.md")

--- a/.claude/skills/catchup/tests/test_deepvista_cards.py
+++ b/.claude/skills/catchup/tests/test_deepvista_cards.py
@@ -1,0 +1,108 @@
+import argparse
+import contextlib
+import importlib.util
+import io
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPT_DIR = Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(SCRIPT_DIR))
+SPEC = importlib.util.spec_from_file_location(
+    "catchup_deepvista_cards", SCRIPT_DIR / "deepvista_cards.py")
+deepvista_cards = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(deepvista_cards)
+
+
+class DeepVistaPushTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.repo = Path(self.tmp.name)
+        self.store = self.repo / "catchup" / "entities"
+        self.store.mkdir(parents=True)
+        self.entity = {
+            "id": "command-scope",
+            "type": "concept",
+            "title": "Command-scoped connection",
+            "summary": "DeepVista connects only for an explicit applied command.",
+            "category": "technical",
+            "status": "active",
+            "tags": [],
+            "links": [],
+            "weeks": {"2026-W35": {"claim": "The preview is local.", "grade": "measured"}},
+            "deepvista": {"card_id": None, "synced_at": None, "content_hash": None},
+        }
+        (self.store / "command-scope.json").write_text(json.dumps(self.entity))
+        self.cfg = {"repo": {"label": "fixture"}, "deepvista": {"enabled": True}}
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def args(self, apply=False):
+        return argparse.Namespace(
+            week="2026-W35", all=False, category=None, status=None, limit=0,
+            force=False, apply=apply, npx=None, timeout=1)
+
+    def test_preview_makes_no_mcp_connection(self):
+        with mock.patch.object(deepvista_cards, "McpClient",
+                               side_effect=AssertionError("preview opened MCP")):
+            out = io.StringIO()
+            with contextlib.redirect_stdout(out):
+                deepvista_cards.cmd_push(
+                    self.args(), str(self.repo), self.cfg, str(self.store))
+        result = json.loads(out.getvalue())
+        self.assertFalse(result["applied"])
+        self.assertIn("No DeepVista call was made", result["next"])
+
+    def test_apply_uses_one_short_lived_client_and_records_card(self):
+        calls = []
+
+        class FakeClient:
+            attempts = 1
+            reinits = 0
+
+            def __init__(self, npx, timeout):
+                calls.append(("open", npx, timeout))
+
+            def call(self, tool, **kwargs):
+                calls.append((tool, kwargs))
+                return {"id": "card-1"}
+
+            def close(self):
+                calls.append(("close",))
+
+        with mock.patch.object(deepvista_cards, "resolve_npx", return_value="/npx"), \
+             mock.patch.object(deepvista_cards, "McpClient", FakeClient):
+            out = io.StringIO()
+            with contextlib.redirect_stdout(out):
+                deepvista_cards.cmd_push(
+                    self.args(apply=True), str(self.repo), self.cfg, str(self.store))
+
+        result = json.loads(out.getvalue())
+        saved = json.loads((self.store / "command-scope.json").read_text())
+        self.assertTrue(result["applied"])
+        self.assertEqual(result["count"], 1)
+        self.assertEqual(saved["deepvista"]["card_id"], "card-1")
+        self.assertEqual(calls[0][0], "open")
+        self.assertEqual(calls[1][0], "upsert_context_card")
+        self.assertEqual(calls[-1], ("close",))
+
+
+class DeepVistaRegistrationTest(unittest.TestCase):
+    def test_repository_mcp_config_does_not_register_deepvista(self):
+        root = Path(__file__).resolve().parents[4]
+        config = root / ".mcp.json"
+        if not config.is_file():
+            return
+        servers = json.loads(config.read_text()).get("mcpServers", {})
+        self.assertNotIn(
+            "api.deepvista.ai/mcp", json.dumps(servers).lower(),
+            "DeepVista must be command-scoped; do not register it in .mcp.json")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/skills/rollup/scripts/deploy.py
+++ b/.claude/skills/rollup/scripts/deploy.py
@@ -52,7 +52,7 @@ SELF_NAME = os.path.basename(SCRIPT)
 # whole class of bug this script exists for gets reintroduced. The two copies of
 # THIS file are kept identical by hand; `diff` them when either changes.
 SKILL_NAME = os.path.basename(SRC_SKILL)
-PARTS = ["SKILL.md", "assets", "reference", "scripts"]
+PARTS = ["SKILL.md", "assets", "reference", "scripts", "tests"]
 # The slash-command file travels with the skill when the source has one. It
 # lives outside the skill directory, so it is compared on its own.
 COMMAND_REL = os.path.join(".claude", "commands", f"{SKILL_NAME}.md")

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,8 +1,3 @@
 {
-  "mcpServers": {
-    "deepvista": {
-      "type": "http",
-      "url": "https://api.deepvista.ai/mcp"
-    }
-  }
+  "mcpServers": {}
 }


### PR DESCRIPTION
## Summary

- remove the ambient host-level MCP registration
- make catchup own a pinned, short-lived proxy only for explicit applied pushes and reads
- keep planning and dry pushes local, with regression coverage
- deploy the new regression suite with the canonical skill

## Verification

- uv run -m unittest discover -s .claude/skills/catchup/tests -v
- JSON configuration validation
- git diff --check

No live external-service call was made during verification.