### PR TITLE
fnr: 2026-W36

### DIFF
--- a/fnr/2026-W36.md
+++ b/fnr/2026-W36.md
@@ -1,0 +1,57 @@
+# 2026-W36 — Aug 31–Sep 6, 2026
+
+<!-- fnr:blurb -->
+The week the tech side went database-first and proved it portable, and both repos spent a fifth of their commits correcting their own record.
+<!-- /fnr:blurb -->
+
+## Building
+
+_506 commits · 59 PRs · 2 open · ~72 commits/day_
+
+Last week's `Next` said storage and APIs first, and that is where the week went.  The tech side moved its store from files into a database — a real data model, an API on top of it, and an agent-facing interface on top of that — with the site building identically from either source, and the two proved equivalent in both directions.  The part I didn't expect to matter: the whole thing now moves between hosting providers by a scripted procedure in about two seconds, with no files in the repo changing.  Authority stays with the files for now, deliberately, until a gated step says otherwise.
+
+The research side now re-checks what it already knows instead of starting over, and every claim about why a technology matters has to pass two independent reviewers before it stands.  The first run of each caught things the system had been getting wrong without knowing it.
+
+Manifesto iterated on, found a way to build "alignment" between Manifesto -> Bets -> Outcomes -> Specs -> Work, and making sure the focus areas move the needle for the overall goals of the project.
+
+**The trip.**  The fun half of the week was planning next week's break: a solo driving trip, out along US-50, try to hit the Navajo Nation, and come back through Route 66.  A ceiling, not a schedule.
+
+**Learning.**  <!-- fnr:building_learning -->
+Building for real is hard, even with AI — so go back to basics.  Build it from the ground up: data model, contracts, APIs.  Separate the agent roles cleanly, and build them individually.
+
+**A northstar, because direction is the scarce thing.**
+<!-- /fnr:building_learning -->
+
+## Fund & Advisory
+
+Four conversations, three founders and one engineering leader: one raising, one expanding into an adjacent offering, one repositioning the product, and one asking the question I spent years on — how do you decide to hire a manager into a team of tech leads.  Elsewhere in the portfolio, one company closed a big Series A.
+
+The fund's analysis needs tweaking: we get data progressively, so it's hard to score on a first pass, and it was redesigned to support "progressive discovery".
+
+**Learning.**  <!-- fnr:fund_learning -->
+Every founder this week asked about doing more, and the useful part of every conversation was the customer on the other side of it: for whom, and what do they buy now that they didn't before.  Building is no longer the constraint, so knowing that is.
+<!-- /fnr:fund_learning -->
+
+## Top of Mind for Founders
+
+<!-- fnr:top_of_mind -->
+If I think about a technical leader helping to guide founders, there are 3 major roles for a leader: setting vision, talent management (hiring, firing and promotion) and technical leadership.  This week was focused on hiring.  Whether it's the first engineer or the fifth, or hiring the first EM, this is your chance to scale.  No matter where you are in your journey, invest in the time: figure out your hiring policy; if you don't have career ladders, decide if it matters; and if you're going to hire your first people manager, what is their role, and how will this affect the makeup and demeanor of your existing team?
+<!-- /fnr:top_of_mind -->
+
+## Interesting Tech
+
+A few things that came through this week's research, with what they do and where to find them.
+
+- **[Harbor](https://harborframework.com)** — an open-source framework for evaluating coding agents, with the sandbox integrations that run each attempt in isolation.
+- **[SWE-bench](https://www.swebench.com)** — the benchmark most coding-agent claims are measured against: real GitHub issues, scored by whether the agent's patch passes the repo's tests.
+- **[Open WebUI](https://openwebui.com)** — a self-hosted chat and agent workspace that runs on open-weight models, for teams that want the assistant experience without depending on one vendor.
+- **[Temporal](https://temporal.io)** — durable execution for long-running workflows: if a step crashes, the workflow resumes where it left off rather than starting over.
+- **[Hermes Agent](https://hermes-agent.nousresearch.com)** — a self-hosted agent runtime from Nous Research: run your own assistant on open-weight models, with checkpoints you can roll back to.
+
+## Next
+
+<!-- fnr:next -->
+Four or five conversations — a coffee, two founder meetings, the monthly partner sync, and the CTO Fund dinner — and one decision with a deadline early in the week.  This week's research was prep for one of those meetings, and should make it richer.  On the build side, launching the API/MCP on real infrastructure.  Then, prep for my free time: I have to remember to take time off, get a little break in my "non-break" career break — the solo car road trip planned above, which is just empty roads, scenic views, and a podcast or two or 10.
+<!-- /fnr:next -->
+
+_Part of a [no-break career break](../roles.md).  How these are made: [fnr/README.md](README.md)._


### PR DESCRIPTION
The weekly for Aug 31–Sep 6, 2026. Written through the one-question flow: the whole week drafted from the record, then one question per turn, with the owner's answers in his words. Released from the private candidate on his explicit publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)