### PR TITLE
catchup: declare cards as database rows, with a typed row_of edge

### DIFF
--- a/.claude/skills/catchup/SKILL.md
+++ b/.claude/skills/catchup/SKILL.md
@@ -762,6 +762,18 @@ manual recovery command for a card created before local write-back completed.
 The free tier is 100 credits a month, and re-pushing an unchanged card spends
 one to change nothing.
 
+**If the repo's config declares `deepvista.databases`**, follow the push with
+the rows pass — a database card's grid is a typed edge the push does not emit,
+so a database whose rows were never declared renders empty:
+
+```bash
+uv run $SKILL/deepvista_cards.py rows --repo . --week <W>           # preview
+uv run $SKILL/deepvista_cards.py rows --repo . --week <W> --apply   # read, write the union
+```
+
+It reads the current rows and writes back the union, so a row someone added in
+the product survives. See `reference/deepvista.md`.
+
 ## Step 5b (optional): Read the week back from DeepVista — the control
 
 Only where the sync is on and the week has been pushed. The cards hold the same

--- a/.claude/skills/catchup/assets/catchup.config.example.json
+++ b/.claude/skills/catchup/assets/catchup.config.example.json
@@ -81,7 +81,9 @@
     "card_types": {
       "$comment": "Override the entity-type -> DeepVista card_type mapping. Values must be DeepVista's own card types.",
       "thread": "topic"
-    }
+    },
+    "$comment_databases": "Database cards this repo fills the rows of. A row is a TYPED edge (rel_type row_of); ordinary relations do not appear in the grid. One database belongs to one repo -- the row list is a full replace, so two writers would delete each other's rows. Run `deepvista_cards.py rows --apply` after a push.",
+    "databases": []
   },
   "subjects": {
     "$comment": "What this repo produces evidence ABOUT, and where that evidence lives. Only meaningful for a repo that evaluates or researches things outside itself; omit it entirely otherwise. Without it the altitude rule is unenforceable — a commit log describes what changed in the repo, and only these artifacts describe the thing being studied, so a learning drifts into being about a defect in the tooling instead of about the subject.",

--- a/.claude/skills/catchup/reference/config.md
+++ b/.claude/skills/catchup/reference/config.md
@@ -202,6 +202,7 @@ work — only a commit that is nothing but bookkeeping is bookkeeping.
 | `tags[]` | `["catchup"]` | Base tags on every card |
 | `card_status` | `"active"` | Must be one of the values the server serves |
 | `card_types{}` | built-in map | Override entity-type → DeepVista card_type |
+| `databases[]` | `[]` | Database cards this repo fills the rows of — see below |
 
 **`card_status` is checked against the served enum** — `pending`,
 `not_started`, `in_progress`, `completed`, `for_review`, `active`, `archived` —
@@ -209,6 +210,49 @@ and a value outside it fails at the first card with the vocabulary printed,
 rather than being accepted and quietly discarded by a server that ignores
 unknown keys. An older `confirmed` is mapped to `active`; it came from a
 REST-era search-visibility flag and was never a member of this enum.
+
+### `databases[]` — the rows of a database card
+
+A DeepVista **database** card renders a grid, and its rows are a *typed* edge:
+`rel_type: "row_of"`. Ids passed as ordinary relations mean only "generally
+related" and **do not appear in the grid**. Each entry names one database card
+and the entities that are its rows:
+
+```json
+"databases": [
+  {
+    "$comment": "Every tracked organization is a row of the tracker card.",
+    "card_id": "<database card id>",
+    "title": "<human label, for command output only>",
+    "types": ["org"],
+    "tags_any": ["tracked"],
+    "weeks": "all"
+  }
+]
+```
+
+| Key | Default | Meaning |
+|---|---|---|
+| `card_id` | — | **Required.** The database card whose rows these are |
+| `title` | `null` | Label in command output; never sent |
+| `types[]` | any | Entity types eligible as rows |
+| `categories[]` | any | Entity categories eligible as rows |
+| `tags_any[]` | any | Entity must carry at least one |
+| `tags_all[]` | none | Entity must carry all |
+| `weeks` | `"all"` | `"all"` for the whole store, `"week"` for one week's entities (then `--week` is required) |
+
+Every clause narrows, so a spec with no selectors takes the repo's whole store
+— which is what a per-week database wants, bounded by `weeks: "week"`.
+
+**A database belongs to exactly one repo's config.** The row list has replace
+semantics per relation type, so two repos writing the same database would
+delete each other's rows by turns. This is the one place the "the repo that
+owns the entity pushes it" rule does not extend: the write lands on the
+database card, not on the row.
+
+Selector keys are closed and validated locally, because a typo is silent at
+the endpoint — it selects nothing, the union writes back what was already
+there, and the grid stays empty with no error anywhere.
 
 ## `git`
 

--- a/.claude/skills/catchup/reference/deepvista.md
+++ b/.claude/skills/catchup/reference/deepvista.md
@@ -158,6 +158,63 @@ per repo with `deepvista.card_types`.
 The body ends with an HTML comment `<!-- catchup-entity: <id> -->`, so a card
 can be traced back to its entity even if its title is edited in the product.
 
+## Database rows — a typed edge, and a full replace
+
+A **database** card renders a grid, and what fills it is not an ordinary
+relation. From `upsert_context_card`'s served schema:
+
+> a database's rows MUST be declared this way, because ids passed in
+> `related_context_card_ids` mean only 'generally related' and will NOT appear
+> in the database's grid
+
+The push emits `related_context_card_ids` and nothing else, so every card it
+has ever written is *related to* things and a *row of* nothing. A database card
+pointed at them renders empty — which is exactly what a tracker built by hand
+in the product did, with a working push behind it and no rows in the grid.
+
+`rows` is the command that fixes it, and it is separate from `push` because it
+writes to a different card:
+
+```bash
+uv run scripts/deepvista_cards.py rows --repo . --week 2026-W35            # preview
+uv run scripts/deepvista_cards.py rows --repo . --week 2026-W35 --apply    # read, then write the union
+```
+
+Two properties of the write shape the whole command, and both cut against the
+way the rest of this bridge works.
+
+**Replace semantics, per relation type.** Passing `row_of` sets the database's
+*full* row list — it leaves `RELATED` alone, but every row it does not name is
+gone. So the apply path reads the current rows first and writes back the union.
+A row that maps to none of this repo's entities is never removed, only carried
+through: someone adding a row in the product must not lose it to the next sync.
+`--prune` is the only way a row is removed, and even then only one that maps to
+one of *our* entities that no longer selects.
+
+A truncated read is therefore fatal, not a warning. If the row listing comes
+back at its cap the command refuses to write, because writing back a truncated
+list would delete the remainder — the one failure here that destroys data
+rather than merely not creating it.
+
+**The write lands on the database, not on the row.** Everywhere else the repo
+that owns an entity pushes it; here the payload is the database's row list. Two
+repos writing one database would clobber each other by turns, so **a database
+belongs to exactly one repo's config** (`deepvista.databases`, see
+`reference/config.md`). That is the one documented exception to the ownership
+rule above.
+
+The update sends the database's own `type`, `title`, `description` and `status`
+back alongside the relations. A links-only upsert — `properties` omitted — is
+what re-saved 41 card bodies through an HTML-escaping pass on 2026-09-02;
+sending properties in the same call left them untouched. The database's body is
+short and plain, but the failure mode is the same one.
+
+The preview is local, like `plan`'s: it lists the rows *this repo would
+contribute* and says plainly that it cannot know the current ones without a
+read. It also reports selected entities with no `card_id` — an entity that was
+never pushed cannot be a row, and an empty-looking grid whose real cause is an
+unfinished push is the confusing case worth naming.
+
 ## The gotcha
 
 **Agent-created cards default to `unconfirmed`, and search filters those out** —

--- a/.claude/skills/catchup/scripts/deepvista_cards.py
+++ b/.claude/skills/catchup/scripts/deepvista_cards.py
@@ -36,6 +36,8 @@ Usage:
     deepvista_cards.py push --week 2026-W35 --apply     # explicit MCP write
     deepvista_cards.py plan --all --category meeting
     deepvista_cards.py plan --week 2026-W35 --show-body    # eyeball the markdown
+    deepvista_cards.py rows --week 2026-W35              # which cards would be rows
+    deepvista_cards.py rows --week 2026-W35 --apply      # read rows, write the union
     deepvista_cards.py record --id ray-summit --card-id abc-123  # recovery only
 """
 
@@ -744,6 +746,241 @@ def cmd_push(args, repo, cfg, sdir):
                                   "reinits": client.reinits}}, indent=2))
 
 
+# ------------------------------------------------------------ database rows
+#
+# A database card's rows are a TYPED edge, and nothing else counts. From
+# `upsert_context_card`'s served schema, read 2026-09-09:
+#
+#   "a database's rows MUST be declared this way, because ids passed in
+#    `related_context_card_ids` mean only 'generally related' and will NOT
+#    appear in the database's grid"
+#
+# This bridge emitted only `related_context_card_ids` until now, so every card
+# it has ever pushed is *related to* things and a *row of* nothing -- which is
+# why a database card pointed at them renders an empty grid. That is the whole
+# defect this command exists to fix.
+#
+# Two properties of the write decide its shape, and both cut against the way
+# the rest of this file works:
+#
+#   REPLACE SEMANTICS, PER rel_type. Passing `row_of` sets the database's FULL
+#   row list (and leaves its RELATED links alone). So a write naming only the
+#   rows this repo knows about DELETES every row anyone else added -- a human
+#   in the product, or another repo. The apply path therefore READS the current
+#   rows first and writes back the union. A row that maps to none of our
+#   entities is never removed, only ever carried through.
+#
+#   THE WRITE LANDS ON THE DATABASE, not on the row. Everywhere else here the
+#   repo that owns an entity pushes it; a database written by two repos would
+#   have them clobbering each other's rows by turns. So a database belongs to
+#   exactly one repo's config, and the union above is the guard for the human
+#   case rather than for a second repo.
+
+ROW_SPEC_KEYS = {"card_id", "title", "types", "categories",
+                 "tags_any", "tags_all", "weeks", "$comment"}
+
+
+def row_databases(cfg):
+    """The `deepvista.databases` specs, validated here rather than at the call.
+
+    A typo in a selector is silent at the endpoint -- it selects nothing, the
+    union writes back exactly what was already there, and the grid stays empty
+    with no error anywhere. So the vocabulary is closed and checked locally.
+    """
+    dv = cfg.get("deepvista") or {}
+    specs = dv.get("databases") or []
+    if isinstance(specs, dict):
+        specs = [specs]
+    out = []
+    for i, s in enumerate(specs):
+        if not isinstance(s, dict) or not s.get("card_id"):
+            die(f"deepvista.databases[{i}] needs a card_id -- the id of the "
+                "database card whose rows these are")
+        unknown = set(s) - ROW_SPEC_KEYS
+        if unknown:
+            die(f"deepvista.databases[{i}] ({s['card_id']}) has unknown keys: "
+                f"{', '.join(sorted(unknown))}. Known: {', '.join(sorted(ROW_SPEC_KEYS))}")
+        if s.get("weeks") not in (None, "all", "week"):
+            die(f"deepvista.databases[{i}] weeks must be \"all\" or \"week\", "
+                f"not {s['weeks']!r}")
+        out.append(s)
+    return out
+
+
+def selects_row(e, spec, week=None):
+    """Whether one entity belongs in this database's grid.
+
+    Every clause is a narrowing filter, so a spec with no selectors at all
+    takes the repo's whole store. That is deliberate -- a week database wants
+    exactly that, bounded by `weeks: "week"`.
+    """
+    if spec.get("types") and e.get("type") not in spec["types"]:
+        return False
+    if spec.get("categories") and e.get("category") not in spec["categories"]:
+        return False
+    own = set(e.get("tags") or [])
+    if spec.get("tags_any") and not own & set(spec["tags_any"]):
+        return False
+    if spec.get("tags_all") and not set(spec["tags_all"]) <= own:
+        return False
+    if spec.get("weeks") == "week" and week not in (e.get("weeks") or {}):
+        return False
+    return True
+
+
+def build_rows_plan(args, repo, cfg, sdir):
+    """Local preview: which of this repo's cards would be rows of which database.
+
+    Deliberately local-only, like `plan`. It cannot know the database's CURRENT
+    rows without a read, and says so rather than implying the list it prints is
+    the list the grid would end up with.
+    """
+    ents = load_all(sdir)
+    repo_label = (cfg.get("repo") or {}).get("label") or os.path.basename(repo)
+    specs = row_databases(cfg)
+    if args.database:
+        specs = [s for s in specs if s["card_id"] == args.database]
+        if not specs:
+            die(f"no deepvista.databases entry with card_id {args.database}")
+    if not specs:
+        die("this repo's config declares no deepvista.databases, so there is no "
+            "grid to fill. See reference/deepvista.md.")
+
+    plan = []
+    for s in specs:
+        if s.get("weeks") == "week" and not args.week:
+            die(f"database {s['card_id']} selects its rows by week; pass --week YYYY-WNN")
+        rows, unpushed = [], []
+        for e in sorted(ents, key=lambda x: x["id"]):
+            if not selects_row(e, s, args.week):
+                continue
+            cid = (e.get("deepvista") or {}).get("card_id")
+            (rows if cid else unpushed).append(
+                {"entity_id": e["id"], "card_id": cid} if cid else e["id"])
+        plan.append({
+            "database": s["card_id"],
+            "title": s.get("title"),
+            "weeks": s.get("weeks") or "all",
+            "ours": rows,
+            # An entity with no card cannot be a row. Reported rather than
+            # skipped silently: an empty-looking grid whose cause is an
+            # unfinished push is the confusing case worth naming.
+            "unpushed": unpushed,
+        })
+    return {
+        "endpoint": MCP_ENDPOINT,
+        "repo": repo_label,
+        "week": args.week,
+        "enabled": (cfg.get("deepvista") or {}).get("enabled", False),
+        "databases": plan,
+    }
+
+
+def _row_ids(listing):
+    """Card ids out of a `list_related_context_cards` reply, order preserved."""
+    items = []
+    if isinstance(listing, dict):
+        items = listing.get("cards") or listing.get("hits") or listing.get("results") or []
+    out = []
+    for it in items:
+        cid = (it or {}).get("card_id") or (it or {}).get("id")
+        if cid and cid not in out:
+            out.append(cid)
+    return out
+
+
+def cmd_rows(args, repo, cfg, sdir):
+    """Declare this repo's cards as rows of its database cards.
+
+    Read the current rows, write back the union, and leave anything we did not
+    put there alone. `--prune` is the one way a row is removed, and even then
+    only a row that maps to one of THIS repo's entities that no longer selects.
+    """
+    dv_cfg = cfg.get("deepvista") or {}
+    if not dv_cfg.get("enabled") and not args.force:
+        die("deepvista.enabled is not true in this repo's config; pass --force to row up anyway")
+
+    result = build_rows_plan(args, repo, cfg, sdir)
+    if not args.apply:
+        result["applied"] = False
+        result["next"] = (
+            "No DeepVista call was made. This preview lists only the rows THIS REPO "
+            "would contribute -- it cannot know the database's current rows without "
+            "reading them. Re-run with --apply to read the existing rows and write "
+            "the union.")
+        print(json.dumps(result, indent=2))
+        return
+
+    ents = load_all(sdir)
+    ours_by_card = {(e.get("deepvista") or {}).get("card_id"): e["id"]
+                    for e in ents if (e.get("deepvista") or {}).get("card_id")}
+
+    npx = resolve_npx(args.npx)
+    if not npx:
+        die(f"no npx {MCP_MIN_NPX}+ found to run the mcp-remote proxy -- `brew install node`, "
+            "or pass --npx /path/to/npx")
+    client = McpClient(npx, timeout=args.timeout)
+    applied = []
+    try:
+        for entry in result["databases"]:
+            db = entry["database"]
+            listing = client.call("list_related_context_cards", card_id=db,
+                                  relation_type="row_of", limit=args.limit)
+            if isinstance(listing, dict) and listing.get("_error"):
+                die(f"list_related_context_cards for {db}: {listing['_error']}")
+            existing = _row_ids(listing)
+            if len(existing) >= args.limit:
+                die(f"database {db} already lists {len(existing)} rows at the read "
+                    f"limit of {args.limit}; raise --limit rather than writing back a "
+                    "truncated row list, which would delete the remainder")
+
+            want = [r["card_id"] for r in entry["ours"]]
+            dropped = []
+            if args.prune:
+                # Only ever a row we recognise as one of our own entities that
+                # no longer selects. A row belonging to nobody we know is not
+                # ours to remove, however stale it looks.
+                keep = []
+                for cid in existing:
+                    if cid in ours_by_card and cid not in want:
+                        dropped.append({"card_id": cid, "entity_id": ours_by_card[cid]})
+                    else:
+                        keep.append(cid)
+                existing = keep
+            merged = existing + [c for c in want if c not in existing]
+            added = [c for c in want if c not in existing]
+
+            if not added and not dropped:
+                applied.append({"database": db, "written": False, "reason": "already current",
+                                "rows": len(merged)})
+                continue
+
+            # Echo the card's own properties back with the relations. A
+            # links-only upsert -- `properties` omitted -- is what re-saved 41
+            # card bodies through an HTML-escaping pass on 2026-09-02; sending
+            # properties in the same call left them untouched. The database's
+            # body is short and plain, but the failure mode is the same one.
+            card = client.call("read_context_card", card_id=db)
+            if not isinstance(card, dict) or card.get("_error") or not card.get("id"):
+                die(f"read_context_card for {db}: "
+                    f"{(card or {}).get('_error', 'no card returned')}")
+            props = {k: card.get(k) for k in ("type", "title", "description", "status")
+                     if card.get(k) is not None}
+            response = client.call(
+                "upsert_context_card", card_id=db, properties=props,
+                relations=[{"card_id": c, "rel_type": "row_of"} for c in merged])
+            if isinstance(response, dict) and response.get("_error"):
+                die(f"upsert_context_card rows for {db}: {response['_error']}")
+            applied.append({"database": db, "written": True, "rows": len(merged),
+                            "added": added, "dropped": dropped,
+                            "carried_through": len(existing) - len(added)})
+    finally:
+        client.close()
+    print(json.dumps({"applied": True, "databases": applied,
+                      "session": {"handshake_attempts": client.attempts,
+                                  "reinits": client.reinits}}, indent=2))
+
+
 def _mentions(text, entity, week=None):
     """Whether a summary actually refers to this entity.
 
@@ -1088,6 +1325,20 @@ def main():
     p.add_argument("--npx", default=None, help="npx to run the mcp-remote proxy with")
     p.add_argument("--timeout", type=int, default=90, help="seconds to wait per call")
     p.set_defaults(fn=cmd_push)
+
+    p = sub.add_parser("rows", parents=[common],
+                       help="declare this repo's cards as ROWS of its database cards")
+    p.add_argument("--week", help="required by a database whose spec says weeks: \"week\"")
+    p.add_argument("--database", default=None, help="only this database card id")
+    p.add_argument("--apply", action="store_true",
+                   help="read the current rows and write the union; omitted means local preview")
+    p.add_argument("--prune", action="store_true",
+                   help="also REMOVE rows that are this repo's entities and no longer select")
+    p.add_argument("--force", action="store_true", help="row up even if deepvista.enabled is false")
+    p.add_argument("--limit", type=int, default=500, help="row-read cap; a full read is required to write safely")
+    p.add_argument("--npx", default=None, help="npx to run the mcp-remote proxy with")
+    p.add_argument("--timeout", type=int, default=90, help="seconds to wait per call")
+    p.set_defaults(fn=cmd_rows)
 
     p = sub.add_parser("record", parents=[common], help="write back the card id after an MCP call")
     p.add_argument("--id", required=True)

--- a/.claude/skills/catchup/tests/test_deepvista_cards.py
+++ b/.claude/skills/catchup/tests/test_deepvista_cards.py
@@ -92,6 +92,177 @@ class DeepVistaPushTest(unittest.TestCase):
         self.assertEqual(calls[-1], ("close",))
 
 
+class DeepVistaRowsTest(unittest.TestCase):
+    """Rows are a typed edge with REPLACE semantics, so the dangerous case is
+    not a failed write -- it is a successful one that silently deletes rows
+    this repo never knew about."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.repo = Path(self.tmp.name)
+        self.store = self.repo / "catchup" / "entities"
+        self.store.mkdir(parents=True)
+        self.write("acme", type="org", tags=["portfolio"], card_id="card-acme")
+        self.write("beta", type="org", tags=["watchlist"], card_id="card-beta")
+        self.write("gamma", type="org", tags=["portfolio"], card_id=None)
+        self.cfg = {
+            "repo": {"label": "fixture"},
+            "deepvista": {
+                "enabled": True,
+                "databases": [{"card_id": "db-1", "types": ["org"],
+                               "tags_any": ["portfolio"]}],
+            },
+        }
+
+    def write(self, eid, type, tags, card_id):
+        (self.store / f"{eid}.json").write_text(json.dumps({
+            "id": eid, "type": type, "title": eid.title(), "summary": "s",
+            "category": "orgs", "status": "active", "tags": tags, "links": [],
+            "weeks": {"2026-W35": {"claim": "c"}},
+            "deepvista": {"card_id": card_id, "synced_at": None, "content_hash": None},
+        }))
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def args(self, **kw):
+        base = dict(week="2026-W35", database=None, apply=False, prune=False,
+                    force=False, limit=500, npx=None, timeout=1)
+        base.update(kw)
+        return argparse.Namespace(**base)
+
+    def run_cmd(self, args, client=None):
+        out = io.StringIO()
+        ctx = mock.patch.object(deepvista_cards, "McpClient",
+                                client or mock.Mock(side_effect=AssertionError("opened MCP")))
+        with mock.patch.object(deepvista_cards, "resolve_npx", return_value="/npx"), ctx:
+            with contextlib.redirect_stdout(out):
+                deepvista_cards.cmd_rows(args, str(self.repo), self.cfg, str(self.store))
+        return json.loads(out.getvalue())
+
+    def test_preview_is_local_and_reports_unpushed(self):
+        result = self.run_cmd(self.args())
+        self.assertFalse(result["applied"])
+        entry = result["databases"][0]
+        self.assertEqual([r["card_id"] for r in entry["ours"]], ["card-acme"])
+        # Selected by tag but never pushed, so it cannot be a row -- and an
+        # empty-looking grid caused by an unfinished push is worth naming.
+        self.assertEqual(entry["unpushed"], ["gamma"])
+
+    def test_apply_writes_the_union_and_never_drops_a_foreign_row(self):
+        seen = []
+
+        class FakeClient:
+            attempts, reinits = 1, 0
+
+            def __init__(self, npx, timeout):
+                pass
+
+            def call(self, tool, **kw):
+                seen.append((tool, kw))
+                if tool == "list_related_context_cards":
+                    # A row a human added in the product, and one of ours.
+                    return {"cards": [{"card_id": "human-row"}, {"card_id": "card-acme"}]}
+                if tool == "read_context_card":
+                    return {"id": "db-1", "type": "database", "title": "DB",
+                            "description": "body", "status": "active"}
+                return {"id": "db-1"}
+
+            def close(self):
+                pass
+
+        result = self.run_cmd(self.args(apply=True), client=FakeClient)
+        self.assertTrue(result["applied"])
+        # card-acme was already a row and nothing else selects, so there is
+        # nothing to add and no credit to spend.
+        self.assertFalse(result["databases"][0]["written"])
+        self.assertEqual(result["databases"][0]["reason"], "already current")
+        self.assertNotIn("upsert_context_card", [t for t, _ in seen])
+
+    def test_apply_sends_properties_with_the_relations(self):
+        seen = []
+
+        class FakeClient:
+            attempts, reinits = 1, 0
+
+            def __init__(self, npx, timeout):
+                pass
+
+            def call(self, tool, **kw):
+                seen.append((tool, kw))
+                if tool == "list_related_context_cards":
+                    return {"cards": [{"card_id": "human-row"}]}
+                if tool == "read_context_card":
+                    return {"id": "db-1", "type": "database", "title": "DB",
+                            "description": "body", "status": "active"}
+                return {"id": "db-1"}
+
+            def close(self):
+                pass
+
+        result = self.run_cmd(self.args(apply=True), client=FakeClient)
+        upsert = [kw for t, kw in seen if t == "upsert_context_card"][0]
+        rows = [r["card_id"] for r in upsert["relations"]]
+        # The human's row survives, ours joins it, and every edge is typed.
+        self.assertEqual(rows, ["human-row", "card-acme"])
+        self.assertTrue(all(r["rel_type"] == "row_of" for r in upsert["relations"]))
+        # Properties travel WITH the relations: a links-only upsert re-saved 41
+        # card bodies through an HTML-escaping pass on 2026-09-02.
+        self.assertEqual(upsert["properties"]["description"], "body")
+        self.assertTrue(result["databases"][0]["written"])
+
+    def test_prune_removes_only_our_own_deselected_rows(self):
+        class FakeClient:
+            attempts, reinits = 1, 0
+
+            def __init__(self, npx, timeout):
+                pass
+
+            def call(self, tool, **kw):
+                if tool == "list_related_context_cards":
+                    # card-beta is ours (watchlist, so no longer selected);
+                    # human-row is nobody's.
+                    return {"cards": [{"card_id": "human-row"},
+                                      {"card_id": "card-beta"}]}
+                if tool == "read_context_card":
+                    return {"id": "db-1", "type": "database", "title": "DB",
+                            "description": "body", "status": "active"}
+                return {"id": "db-1"}
+
+            def close(self):
+                pass
+
+        result = self.run_cmd(self.args(apply=True, prune=True), client=FakeClient)
+        entry = result["databases"][0]
+        self.assertEqual([d["entity_id"] for d in entry["dropped"]], ["beta"])
+        self.assertEqual(entry["added"], ["card-acme"])
+
+    def test_a_truncated_row_read_refuses_to_write(self):
+        class FakeClient:
+            attempts, reinits = 1, 0
+
+            def __init__(self, npx, timeout):
+                pass
+
+            def call(self, tool, **kw):
+                if tool == "list_related_context_cards":
+                    return {"cards": [{"card_id": f"r{i}"} for i in range(3)]}
+                return {"id": "db-1"}
+
+            def close(self):
+                pass
+
+        # Writing back a truncated row list would delete the remainder, so the
+        # read hitting its cap has to be fatal rather than merely noted.
+        with self.assertRaises(SystemExit):
+            self.run_cmd(self.args(apply=True, limit=3), client=FakeClient)
+
+    def test_unknown_selector_key_fails_locally(self):
+        self.cfg["deepvista"]["databases"] = [{"card_id": "db-1", "tags": ["oops"]}]
+        with self.assertRaises(SystemExit):
+            deepvista_cards.row_databases(self.cfg)
+
+
 class DeepVistaRegistrationTest(unittest.TestCase):
     def test_repository_mcp_config_does_not_register_deepvista(self):
         root = Path(__file__).resolve().parents[4]


### PR DESCRIPTION
A DeepVista **database** card renders a grid, and its rows are a *typed* edge. From `upsert_context_card`'s served schema:

> a database's rows MUST be declared this way, because ids passed in `related_context_card_ids` mean only 'generally related' and will NOT appear in the database's grid

The push emits `related_context_card_ids` and nothing else, so every card this bridge has ever written is *related to* things and a *row of* nothing. A database card pointed at them renders empty with a perfectly working push behind it.

Adds a `rows` command — separate from `push`, because it writes to a different card — driven by a new `deepvista.databases` config block.

## What shapes it

Two properties of the write, both cutting against the way the rest of the bridge works:

**Replace semantics per `rel_type`.** Passing `row_of` sets the database's *full* row list, so a write naming only our rows deletes everyone else's. The apply path reads the current rows and writes back the **union**; a row that maps to none of this repo's entities is carried through, never removed — someone adding a row in the product must not lose it to the next sync. `--prune` is the only removal path, and only of our own deselected rows. A row read that returns at its cap is **fatal**: writing back a truncated list would delete the remainder, the one failure here that destroys data rather than merely not creating it.

**The write lands on the database, not the row.** Everywhere else the repo that owns an entity pushes it. Two repos writing one database would clobber each other by turns, so a database belongs to exactly one repo's config — documented as the one exception to that ownership rule.

Properties travel with the relations: a links-only upsert is what re-saved 41 card bodies through an HTML-escaping pass on 2026-09-02.

## Preview stays local

Like `plan`'s, and it says plainly that it cannot know the current rows without a read. It also reports selected entities with **no `card_id`** — an entity never pushed cannot be a row, and an empty-looking grid whose real cause is an unfinished push is the confusing case worth naming.

## Verification

- 9 tests pass, 6 new — union preserves a foreign row, prune removes only our own deselected ones, properties travel with relations, a truncated read refuses to write, an unknown selector key fails locally, and no-change spends no credit.
- Smoke-tested against a real store: 26 entities selected for a week, 0 unpushed, no network call on preview.
- Error path checked in a repo with no `databases` configured.

No card was written to DeepVista in preparing this. Targets need a `deploy.py` redeploy plus a `databases` block before `rows` does anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)