### PR TITLE
catchup: carry the record onto the card — owed/asks, the room, and the tech lane

### DIFF
--- a/.claude/skills/catchup/reference/deepvista.md
+++ b/.claude/skills/catchup/reference/deepvista.md
@@ -170,9 +170,16 @@ After a renderer change, re-push the affected slice with `--force`, narrowly,
 because that is one credit per card:
 
 ```bash
-uv run scripts/deepvista_cards.py plan --repo . --all --category meeting --force
-uv run scripts/deepvista_cards.py push --repo . --all --category meeting --force --apply
+uv run scripts/deepvista_cards.py plan --repo . --all --type meeting --force
+uv run scripts/deepvista_cards.py push --repo . --all --type meeting --force --apply
 ```
+
+**Narrow by `--type`, not `--category`.** The category is the *summary bucket*
+and is much broader than it reads: on a relationship repo `category: meeting`
+holds the people, the companies, the decisions and the corrections too — 111
+entities against 15 of `type: meeting`. A renderer fix that changes only
+meeting bodies re-pushed by category spends a credit each on about a hundred
+cards whose bodies are byte-identical.
 
 Hashing the rendered body instead would make this automatic. It would also
 invalidate every stored hash at once -- a full re-push of the entire store on

--- a/.claude/skills/catchup/reference/deepvista.md
+++ b/.claude/skills/catchup/reference/deepvista.md
@@ -158,6 +158,27 @@ per repo with `deepvista.card_types`.
 The body ends with an HTML comment `<!-- catchup-entity: <id> -->`, so a card
 can be traced back to its entity even if its title is edited in the product.
 
+## A renderer change does not dirty the hash
+
+`content_hash` covers the **entity**, not the rendered card. So a change to
+`render_body` -- a field that was never emitted, a layout fix -- alters what
+every card should say while every entity hashes exactly as before, and `plan`
+reports the whole store as `skip`. The improvement ships to no card at all,
+silently and at no cost, which is the worst combination for noticing.
+
+After a renderer change, re-push the affected slice with `--force`, narrowly,
+because that is one credit per card:
+
+```bash
+uv run scripts/deepvista_cards.py plan --repo . --all --category meeting --force
+uv run scripts/deepvista_cards.py push --repo . --all --category meeting --force --apply
+```
+
+Hashing the rendered body instead would make this automatic. It would also
+invalidate every stored hash at once -- a full re-push of the entire store on
+the next run -- so it is a deliberate decision with a credit bill attached, not
+a tidy-up.
+
 ## The gotcha
 
 **Agent-created cards default to `unconfirmed`, and search filters those out** —

--- a/.claude/skills/catchup/scripts/deepvista_cards.py
+++ b/.claude/skills/catchup/scripts/deepvista_cards.py
@@ -403,6 +403,21 @@ def render_body(e, titles, repo_label):
         if blk.get("note"):
             lines.append("")
             lines.append(blk["note"].strip())
+
+        # What is owed and what is still to ask -- the half of a conversation
+        # that EXPIRES. The local summary has rendered these as sub-bullets
+        # since the meetings format was rewritten; this renderer never emitted
+        # them, so every meeting card could say what the conversation was about
+        # and nothing about what it left outstanding. Found by the W35 control
+        # run, when the card-only fund summary came back unable to name a single
+        # follow-up, and open through W36.
+        for label, key in (("Owed", "owed"), ("Ask", "asks")):
+            items = [" ".join(str(i).split()) for i in (blk.get(key) or []) if str(i).strip()]
+            if items:
+                lines.append("")
+                lines.append(f"**{label}:**")
+                lines += [f"- {x}" for x in items]
+
         ev = []
         if blk.get("people"):
             ev.append("People: " + ", ".join(blk["people"]))

--- a/.claude/skills/catchup/scripts/deepvista_cards.py
+++ b/.claude/skills/catchup/scripts/deepvista_cards.py
@@ -561,6 +561,13 @@ def build_plan(args, repo, cfg, sdir):
         die("pass --week YYYY-WNN or --all")
     if args.category:
         ents = [e for e in ents if e.get("category") == args.category]
+    # `category` is the summary bucket and is much broader than it reads: on a
+    # relationship repo `meeting` holds the people, the companies, the decisions
+    # and the corrections too -- 111 entities where `type: meeting` is 15. So a
+    # renderer fix that only changes meeting BODIES needs the type, or the
+    # --force re-push spends a credit each on a hundred cards it does not alter.
+    if getattr(args, "type", None):
+        ents = [e for e in ents if e.get("type") == args.type]
     if args.status:
         ents = [e for e in ents if e.get("status") == args.status]
 
@@ -1059,6 +1066,8 @@ def main():
     p.add_argument("--week")
     p.add_argument("--all", action="store_true")
     p.add_argument("--category", choices=CATEGORY_ORDER)
+    p.add_argument("--type", choices=sorted(CARD_TYPE),
+                   help="entity type — narrower than --category, which is the summary bucket")
     p.add_argument("--status")
     p.add_argument("--force", action="store_true", help="re-push even if unchanged")
     p.add_argument("--show-body", action="store_true", help="full markdown, not truncated")
@@ -1096,6 +1105,8 @@ def main():
     p.add_argument("--week")
     p.add_argument("--all", action="store_true")
     p.add_argument("--category", choices=CATEGORY_ORDER)
+    p.add_argument("--type", choices=sorted(CARD_TYPE),
+                   help="entity type — narrower than --category, which is the summary bucket")
     p.add_argument("--status")
     p.add_argument("--limit", type=int, default=0)
     p.add_argument("--force", action="store_true", help="re-push unchanged cards or override disabled config")

--- a/.claude/skills/catchup/scripts/deepvista_cards.py
+++ b/.claude/skills/catchup/scripts/deepvista_cards.py
@@ -331,7 +331,7 @@ def card_status(dv_cfg):
     return want
 
 
-def render_body(e, titles, repo_label):
+def render_body(e, titles, repo_label, by_id=None):
     """The card's markdown body.
 
     Carries the full week-by-week timeline, not just the current summary. That is
@@ -339,6 +339,13 @@ def render_body(e, titles, repo_label):
     that the cards should hold enough for DeepVista to compose a catchup itself.
     A card that only said "here is the latest" could not.
     """
+    by_id = by_id or {}
+
+    def name(eid):
+        """An entity id as a reader's name. Falls back to the id itself, which
+        is what a card said for attendees before they were rendered at all."""
+        return by_id.get(eid) or eid
+
     weeks = sorted(e.get("weeks") or {})
     lines = [e.get("summary", "").strip(), ""]
 
@@ -384,6 +391,16 @@ def render_body(e, titles, repo_label):
                 bits.append(f"{wt['commits']} commits")
             lines.append("")
             lines.append("**Weight:** " + " · ".join(bits))
+        # What became of the theme, and what it cost or bought. A theme card
+        # that carries `moved` and not `disposition` says what happened and not
+        # whether it stuck -- and `dropped` is the single most useful thing a
+        # later reader can know about a week's theme.
+        if blk.get("disposition"):
+            lines.append("")
+            lines.append(f"**Disposition:** {blk['disposition']}")
+        if blk.get("consequence"):
+            lines.append("")
+            lines.append(f"**Consequence:** {str(blk['consequence']).strip()}")
         if blk.get("evidence"):
             lines.append("")
             lines.append("**Evidence:**")
@@ -391,8 +408,10 @@ def render_body(e, titles, repo_label):
 
         if blk.get("claim"):
             grade = blk.get("grade")
+            rank = blk.get("rank")
             lines.append(f"**Claim:** {blk['claim'].strip()}"
-                         + (f"  *[{grade}]*" if grade else ""))
+                         + (f"  *[{grade}]*" if grade else "")
+                         + (f"  *[rank {rank}]*" if rank else ""))
         if blk.get("so_what"):
             lines.append("")
             lines.append(blk["so_what"].strip())
@@ -419,10 +438,18 @@ def render_body(e, titles, repo_label):
                 lines += [f"- {x}" for x in items]
 
         ev = []
+        # Who was in the room. `attendees` is the canonical field -- the one
+        # contact_state derives "have I met this person" from -- and it never
+        # reached the card, so 4 of the fund's 15 meeting cards named nobody at
+        # all and the rest named only whoever also appeared in `people`.
+        if blk.get("attendees"):
+            ev.append("In the room: " + ", ".join(name(a) for a in blk["attendees"]))
         if blk.get("people"):
             ev.append("People: " + ", ".join(blk["people"]))
         if blk.get("prs"):
             ev.append("PRs: " + ", ".join(f"#{p}" for p in blk["prs"]))
+        if blk.get("open_prs"):
+            ev.append("Still open: " + ", ".join(f"#{p}" for p in blk["open_prs"]))
         if blk.get("commits"):
             ev.append("Commits: " + ", ".join(blk["commits"][:8])
                       + (f" (+{len(blk['commits']) - 8} more)" if len(blk["commits"]) > 8 else ""))
@@ -433,10 +460,20 @@ def render_body(e, titles, repo_label):
             lines += [f"- {x}" for x in ev]
         lines.append("")
 
+    if e.get("urls"):
+        lines.append("## Published")
+        lines.append("")
+        for u in e["urls"]:
+            if isinstance(u, dict) and u.get("url"):
+                lines.append(f"- [{u.get('label') or u['url']}]({u['url']})")
+            elif u:
+                lines.append(f"- {u}")
+        lines.append("")
+
     if e.get("links"):
         lines.append("## Related")
         lines.append("")
-        lines += [f"- `{l}`" for l in e["links"]]
+        lines += [f"- {name(l)} (`{l}`)" for l in e["links"]]
         lines.append("")
 
     lines.append(f"<!-- catchup-entity: {e['id']} -->")
@@ -567,7 +604,7 @@ def build_plan(args, repo, cfg, sdir):
     # renderer fix that only changes meeting BODIES needs the type, or the
     # --force re-push spends a credit each on a hundred cards it does not alter.
     if getattr(args, "type", None):
-        ents = [e for e in ents if e.get("type") == args.type]
+        ents = [e for e in ents if e.get("type") in set(args.type)]
     if args.status:
         ents = [e for e in ents if e.get("status") == args.status]
 
@@ -581,6 +618,7 @@ def build_plan(args, repo, cfg, sdir):
     card_of = {x["id"]: (x.get("deepvista") or {}).get("card_id")
                for x in all_ents if (x.get("deepvista") or {}).get("card_id")}
 
+    by_id = {x["id"]: x.get("title") for x in all_ents if x.get("title")}
     plan, counts = [], {"create": 0, "update": 0, "skip": 0}
     for e in sorted(ents, key=lambda x: (CATEGORY_ORDER.index(x.get("category", "other"))
                                          if x.get("category") in CATEGORY_ORDER else 9, x["id"])):
@@ -626,7 +664,7 @@ def build_plan(args, repo, cfg, sdir):
             "card": {
                 "type": type_map.get(e.get("type"), "note"),
                 "title": e["title"],
-                "description": render_body(e, titles, repo_label),
+                "description": render_body(e, titles, repo_label, by_id),
                 "tags": build_tags(e, cfg, repo_label, all_ents),
                 "status": card_status(dv_cfg),
             },
@@ -973,7 +1011,8 @@ def cmd_fetch(args, repo, cfg, sdir):
                 continue
             body = card.get("description") or ""
             tracer = _tracer_state(body, e["id"])
-            state = _body_state(body, render_body(e, titles, repo_label), tracer)
+            state = _body_state(body, render_body(e, titles, repo_label,
+                                     {x['id']: x.get('title') for x in all_ents if x.get('title')}), tracer)
             cards.append({
                 "entity_id": e["id"],
                 "entity_type": e.get("type"),
@@ -1066,8 +1105,9 @@ def main():
     p.add_argument("--week")
     p.add_argument("--all", action="store_true")
     p.add_argument("--category", choices=CATEGORY_ORDER)
-    p.add_argument("--type", choices=sorted(CARD_TYPE),
-                   help="entity type — narrower than --category, which is the summary bucket")
+    p.add_argument("--type", choices=sorted(CARD_TYPE), nargs="+", metavar="TYPE",
+                   help="one or more entity types — narrower than --category, which is "
+                        "the summary bucket. A renderer change usually touches several.")
     p.add_argument("--status")
     p.add_argument("--force", action="store_true", help="re-push even if unchanged")
     p.add_argument("--show-body", action="store_true", help="full markdown, not truncated")
@@ -1105,8 +1145,9 @@ def main():
     p.add_argument("--week")
     p.add_argument("--all", action="store_true")
     p.add_argument("--category", choices=CATEGORY_ORDER)
-    p.add_argument("--type", choices=sorted(CARD_TYPE),
-                   help="entity type — narrower than --category, which is the summary bucket")
+    p.add_argument("--type", choices=sorted(CARD_TYPE), nargs="+", metavar="TYPE",
+                   help="one or more entity types — narrower than --category, which is "
+                        "the summary bucket. A renderer change usually touches several.")
     p.add_argument("--status")
     p.add_argument("--limit", type=int, default=0)
     p.add_argument("--force", action="store_true", help="re-push unchanged cards or override disabled config")

--- a/.claude/skills/catchup/scripts/entities.py
+++ b/.claude/skills/catchup/scripts/entities.py
@@ -228,11 +228,19 @@ def load_all(sdir):
 
 
 def content_hash(e):
-    """Hash of everything a DeepVista card would carry.
+    """Hash of the ENTITY a DeepVista card is rendered from -- not of the card.
 
     The sync compares this to what it last pushed, so an unchanged entity costs
     no API call and no credit. Deliberately excludes the `deepvista` block, which
     the sync itself writes -- otherwise every push would dirty its own input.
+
+    The gap to know about: a change to `render_body` alters what the card says
+    without touching the entity, so every already-pushed card hashes as `skip`
+    and the improvement never ships. Re-push the affected category with
+    `--force` after a renderer change -- narrowly, since that is a credit per
+    card. Hashing the rendered body instead would make this automatic and would
+    also invalidate every stored hash at once, which is a full re-push of every
+    card in the store; worth doing deliberately, not as a side effect.
     """
     payload = {k: v for k, v in e.items()
                if k not in ("deepvista", "_path", "updated_at")}

--- a/.claude/skills/catchup/tests/test_deepvista_cards.py
+++ b/.claude/skills/catchup/tests/test_deepvista_cards.py
@@ -137,6 +137,55 @@ class DeepVistaCardBodyTest(unittest.TestCase):
         self.assertNotIn("**Ask:**", body)
 
 
+class DeepVistaTechFieldsTest(unittest.TestCase):
+    """The tech lane had the same defect as meetings, and more of it.
+
+    A theme card carried what MOVED and never whether it stuck; a concept card
+    carried a claim and never its rank; and PRs still open, where an entity is
+    published, and who was in the room reached no card at all.
+    """
+
+    def test_theme_carries_disposition_and_consequence(self):
+        e = {"id": "t", "type": "theme", "title": "T", "summary": "s",
+             "category": "technical", "status": "active",
+             "weeks": {"2026-W36": {"moved": "Rebuilt the ladder.",
+                                    "disposition": "dropped",
+                                    "consequence": "Cost a week and bought nothing."}}}
+        body = deepvista_cards.render_body(e, {}, "fixture")
+        self.assertIn("**Disposition:** dropped", body)
+        self.assertIn("**Consequence:** Cost a week and bought nothing.", body)
+
+    def test_concept_claim_carries_its_rank_beside_its_grade(self):
+        e = {"id": "c", "type": "concept", "title": "C", "summary": "s",
+             "category": "technical", "status": "active",
+             "weeks": {"2026-W36": {"claim": "A cache hit is a validated computation.",
+                                    "grade": "measured", "rank": 2}}}
+        body = deepvista_cards.render_body(e, {}, "fixture")
+        self.assertIn("*[measured]*", body)
+        self.assertIn("*[rank 2]*", body)
+
+    def test_attendees_render_as_names_and_open_prs_as_still_open(self):
+        e = {"id": "m", "type": "meeting", "title": "M", "summary": "s",
+             "category": "meeting", "status": "active",
+             "links": ["dana-lee"],
+             "weeks": {"2026-W36": {"attendees": ["dana-lee", "unknown-id"],
+                                    "prs": ["12"], "open_prs": ["13"]}}}
+        body = deepvista_cards.render_body(e, {}, "fixture", {"dana-lee": "Dana Lee"})
+        self.assertIn("In the room: Dana Lee, unknown-id", body)   # id is the fallback
+        self.assertIn("Still open: #13", body)
+        # Related resolves the same way, so a card reads as names not slugs.
+        self.assertIn("- Dana Lee (`dana-lee`)", body)
+
+    def test_published_urls_reach_the_card(self):
+        e = {"id": "p", "type": "thread", "title": "P", "summary": "s",
+             "category": "technical", "status": "active",
+             "urls": [{"label": "index", "url": "https://example.com/x/"}],
+             "weeks": {"2026-W36": {"note": "n"}}}
+        body = deepvista_cards.render_body(e, {}, "fixture")
+        self.assertIn("## Published", body)
+        self.assertIn("- [index](https://example.com/x/)", body)
+
+
 class DeepVistaTypeFilterTest(unittest.TestCase):
     """`category` is the summary bucket, not the entity type.
 
@@ -164,11 +213,18 @@ class DeepVistaTypeFilterTest(unittest.TestCase):
         self.tmp.cleanup()
 
     def test_type_narrows_within_a_category(self):
-        args = argparse.Namespace(week=None, all=True, category="meeting", type="meeting",
+        args = argparse.Namespace(week=None, all=True, category="meeting", type=["meeting"],
                                   status=None, limit=0, force=True, show_body=True,
                                   include_skipped=False)
         result = deepvista_cards.build_plan(args, str(self.repo), self.cfg, str(self.store))
         self.assertEqual([i["entity_id"] for i in result["plan"]], ["m1"])
+
+    def test_several_types_at_once(self):
+        args = argparse.Namespace(week=None, all=True, category=None, type=["meeting", "org"],
+                                  status=None, limit=0, force=True, show_body=True,
+                                  include_skipped=False)
+        result = deepvista_cards.build_plan(args, str(self.repo), self.cfg, str(self.store))
+        self.assertEqual(sorted(i["entity_id"] for i in result["plan"]), ["m1", "o1"])
 
     def test_category_alone_still_takes_the_whole_bucket(self):
         args = argparse.Namespace(week=None, all=True, category="meeting", type=None,

--- a/.claude/skills/catchup/tests/test_deepvista_cards.py
+++ b/.claude/skills/catchup/tests/test_deepvista_cards.py
@@ -137,6 +137,47 @@ class DeepVistaCardBodyTest(unittest.TestCase):
         self.assertNotIn("**Ask:**", body)
 
 
+class DeepVistaTypeFilterTest(unittest.TestCase):
+    """`category` is the summary bucket, not the entity type.
+
+    On a relationship repo `category: meeting` holds the people, companies,
+    decisions and corrections as well -- 111 entities where `type: meeting` is
+    15. A renderer fix that only changes meeting bodies needs the type, or the
+    --force re-push spends a credit each on a hundred unchanged cards.
+    """
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.repo = Path(self.tmp.name)
+        self.store = self.repo / "catchup" / "entities"
+        self.store.mkdir(parents=True)
+        for eid, etype in (("m1", "meeting"), ("p1", "person"), ("o1", "org")):
+            (self.store / f"{eid}.json").write_text(json.dumps({
+                "id": eid, "type": etype, "title": eid, "summary": "s",
+                "category": "meeting", "status": "active", "tags": [], "links": [],
+                "weeks": {"2026-W35": {"note": "n"}},
+                "deepvista": {"card_id": f"card-{eid}", "content_hash": None},
+            }))
+        self.cfg = {"repo": {"label": "fixture"}, "deepvista": {"enabled": True}}
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_type_narrows_within_a_category(self):
+        args = argparse.Namespace(week=None, all=True, category="meeting", type="meeting",
+                                  status=None, limit=0, force=True, show_body=True,
+                                  include_skipped=False)
+        result = deepvista_cards.build_plan(args, str(self.repo), self.cfg, str(self.store))
+        self.assertEqual([i["entity_id"] for i in result["plan"]], ["m1"])
+
+    def test_category_alone_still_takes_the_whole_bucket(self):
+        args = argparse.Namespace(week=None, all=True, category="meeting", type=None,
+                                  status=None, limit=0, force=True, show_body=True,
+                                  include_skipped=False)
+        result = deepvista_cards.build_plan(args, str(self.repo), self.cfg, str(self.store))
+        self.assertEqual(len(result["plan"]), 3)
+
+
 class DeepVistaRegistrationTest(unittest.TestCase):
     def test_repository_mcp_config_does_not_register_deepvista(self):
         root = Path(__file__).resolve().parents[4]

--- a/.claude/skills/catchup/tests/test_deepvista_cards.py
+++ b/.claude/skills/catchup/tests/test_deepvista_cards.py
@@ -92,6 +92,51 @@ class DeepVistaPushTest(unittest.TestCase):
         self.assertEqual(calls[-1], ("close",))
 
 
+class DeepVistaCardBodyTest(unittest.TestCase):
+    def test_meeting_card_carries_what_is_owed_and_still_to_ask(self):
+        """The half of a conversation that expires.
+
+        The local summary has rendered these as sub-bullets since the meetings
+        format was rewritten; the card renderer never emitted them, so the W35
+        control's card-only summary could say what every conversation was about
+        and not one thing it left outstanding.
+        """
+        entity = {
+            "id": "meeting-acme",
+            "type": "meeting",
+            "title": "Acme — Dana",
+            "summary": "First call.",
+            "category": "meetings",
+            "status": "active",
+            "weeks": {"2026-W35": {
+                "date": "2026-08-27",
+                "note": "They walked through the pipeline.",
+                "owed": ["Intro to the   infra lead", "Send the memo"],
+                "asks": ["Their churn number"],
+                "people": ["dana"],
+            }},
+        }
+        body = deepvista_cards.render_body(entity, {"meetings": "Meetings"}, "fixture")
+        self.assertIn("**Owed:**", body)
+        self.assertIn("- Intro to the infra lead", body)   # whitespace collapsed
+        self.assertIn("- Send the memo", body)
+        self.assertIn("**Ask:**", body)
+        self.assertIn("- Their churn number", body)
+        # The note is the synthesis and still leads; the actions follow it.
+        self.assertLess(body.index("They walked through"), body.index("**Owed:**"))
+        self.assertLess(body.index("**Owed:**"), body.index("**Ask:**"))
+
+    def test_an_entity_with_neither_gains_no_empty_headings(self):
+        entity = {
+            "id": "concept-x", "type": "concept", "title": "X", "summary": "s",
+            "category": "technical", "status": "active",
+            "weeks": {"2026-W35": {"claim": "c", "owed": [], "asks": None}},
+        }
+        body = deepvista_cards.render_body(entity, {}, "fixture")
+        self.assertNotIn("**Owed:**", body)
+        self.assertNotIn("**Ask:**", body)
+
+
 class DeepVistaRegistrationTest(unittest.TestCase):
     def test_repository_mcp_config_does_not_register_deepvista(self):
         root = Path(__file__).resolve().parents[4]


### PR DESCRIPTION
`render_body` dropped most of what the entities hold. The DeepVista cards have been thin in ways that only surfaced when the control tried to write a week from them alone — and the fix started at meetings, then an audit of *every* field in both stores against every field the renderer emits found the tech lane was worse.

## What now reaches the card

| Field | Was | Is |
|---|---|---|
| `owed` / `asks` | absent | what a conversation left outstanding — the half that expires |
| `attendees` | absent | **who was in the room**, with roles and companies |
| `disposition` | absent | what became of a theme — `dropped` is the most useful thing a later reader can know |
| `consequence` | absent | what it cost or bought |
| `rank` | absent | a concept's rank, beside its grade on the claim line |
| `open_prs` | absent | "Still open: #NN" |
| `urls` | absent | a `## Published` section |

**Every week-block field in both stores now renders.** Left out deliberately: `first_seen` / `last_seen` / `updated_at` (metadata), `theme` (already a graph edge) and `anchor` (a summary-layout concern).

`attendees` is the striking one. It is the canonical field — the one `contact_state` derives "have I met this person" from — and it reached no card at all. **4 of 15 meeting cards named nobody**; the rest named only whoever also appeared in `people`. It was always already in `links`, so the graph edge existed and only the body was silent. Related entries now read as names with their id rather than bare slugs, through the same map.

## Two things the work surfaced

**`content_hash` covers the entity, not the card.** It claimed to hash *"everything a DeepVista card would carry"*. So a renderer change alters what every card should say while every entity hashes identically, `plan` reports the whole store as `skip`, and the improvement ships nowhere — silently and at no cost, the worst combination for noticing. Docstring corrected and the `--force` re-push documented. Hashing the body instead would fix it automatically *and* invalidate every stored hash at once, which is a full re-push of the store — a deliberate decision with a bill attached, so not in this PR.

**`--category` is the summary bucket, not the type.** On a relationship repo `category: meeting` holds the people, companies, decisions and corrections too — 111 entities against 15 of `type: meeting`. Added `--type`, with `nargs`, because a renderer change touches several types at once: this one changes 38 of the fund store's 126 across six of them.

## Verification

12 tests pass, 9 new. Rendered against both real stores; a re-audit confirms no week-block field is dropped. Affected: **38 of 126** (a target repo), **17 of 45** (a target repo).

No card was written to DeepVista. The prepared re-push is the target repo's sync PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
