### PR TITLE
catchup: complete DeepVista cards, database rows, and deploys from current main

### DIFF
--- a/.claude/skills/catchup/SKILL.md
+++ b/.claude/skills/catchup/SKILL.md
@@ -762,6 +762,18 @@ manual recovery command for a card created before local write-back completed.
 The free tier is 100 credits a month, and re-pushing an unchanged card spends
 one to change nothing.
 
+**If the repo's config declares `deepvista.databases`**, follow the push with
+the rows pass — a database card's grid is a typed edge the push does not emit,
+so a database whose rows were never declared renders empty:
+
+```bash
+uv run $SKILL/deepvista_cards.py rows --repo . --week <W>           # preview
+uv run $SKILL/deepvista_cards.py rows --repo . --week <W> --apply   # read, write the union
+```
+
+It reads the current rows and writes back the union, so a row someone added in
+the product survives. See `reference/deepvista.md`.
+
 ## Step 5b (optional): Read the week back from DeepVista — the control
 
 Only where the sync is on and the week has been pushed. The cards hold the same

--- a/.claude/skills/catchup/assets/catchup.config.example.json
+++ b/.claude/skills/catchup/assets/catchup.config.example.json
@@ -81,7 +81,9 @@
     "card_types": {
       "$comment": "Override the entity-type -> DeepVista card_type mapping. Values must be DeepVista's own card types.",
       "thread": "topic"
-    }
+    },
+    "$comment_databases": "Database cards this repo fills the rows of. A row is a TYPED edge (rel_type row_of); ordinary relations do not appear in the grid. One database belongs to one repo -- the row list is a full replace, so two writers would delete each other's rows. Run `deepvista_cards.py rows --apply` after a push.",
+    "databases": []
   },
   "subjects": {
     "$comment": "What this repo produces evidence ABOUT, and where that evidence lives. Only meaningful for a repo that evaluates or researches things outside itself; omit it entirely otherwise. Without it the altitude rule is unenforceable — a commit log describes what changed in the repo, and only these artifacts describe the thing being studied, so a learning drifts into being about a defect in the tooling instead of about the subject.",

--- a/.claude/skills/catchup/reference/config.md
+++ b/.claude/skills/catchup/reference/config.md
@@ -202,6 +202,7 @@ work — only a commit that is nothing but bookkeeping is bookkeeping.
 | `tags[]` | `["catchup"]` | Base tags on every card |
 | `card_status` | `"active"` | Must be one of the values the server serves |
 | `card_types{}` | built-in map | Override entity-type → DeepVista card_type |
+| `databases[]` | `[]` | Database cards this repo fills the rows of — see below |
 
 **`card_status` is checked against the served enum** — `pending`,
 `not_started`, `in_progress`, `completed`, `for_review`, `active`, `archived` —
@@ -209,6 +210,49 @@ and a value outside it fails at the first card with the vocabulary printed,
 rather than being accepted and quietly discarded by a server that ignores
 unknown keys. An older `confirmed` is mapped to `active`; it came from a
 REST-era search-visibility flag and was never a member of this enum.
+
+### `databases[]` — the rows of a database card
+
+A DeepVista **database** card renders a grid, and its rows are a *typed* edge:
+`rel_type: "row_of"`. Ids passed as ordinary relations mean only "generally
+related" and **do not appear in the grid**. Each entry names one database card
+and the entities that are its rows:
+
+```json
+"databases": [
+  {
+    "$comment": "Every tracked organization is a row of the tracker card.",
+    "card_id": "<database card id>",
+    "title": "<human label, for command output only>",
+    "types": ["org"],
+    "tags_any": ["tracked"],
+    "weeks": "all"
+  }
+]
+```
+
+| Key | Default | Meaning |
+|---|---|---|
+| `card_id` | — | **Required.** The database card whose rows these are |
+| `title` | `null` | Label in command output; never sent |
+| `types[]` | any | Entity types eligible as rows |
+| `categories[]` | any | Entity categories eligible as rows |
+| `tags_any[]` | any | Entity must carry at least one |
+| `tags_all[]` | none | Entity must carry all |
+| `weeks` | `"all"` | `"all"` for the whole store, `"week"` for one week's entities (then `--week` is required) |
+
+Every clause narrows, so a spec with no selectors takes the repo's whole store
+— which is what a per-week database wants, bounded by `weeks: "week"`.
+
+**A database belongs to exactly one repo's config.** The row list has replace
+semantics per relation type, so two repos writing the same database would
+delete each other's rows by turns. This is the one place the "the repo that
+owns the entity pushes it" rule does not extend: the write lands on the
+database card, not on the row.
+
+Selector keys are closed and validated locally, because a typo is silent at
+the endpoint — it selects nothing, the union writes back what was already
+there, and the grid stays empty with no error anywhere.
 
 ## `git`
 

--- a/.claude/skills/catchup/reference/deepvista.md
+++ b/.claude/skills/catchup/reference/deepvista.md
@@ -170,9 +170,16 @@ After a renderer change, re-push the affected slice with `--force`, narrowly,
 because that is one credit per card:
 
 ```bash
-uv run scripts/deepvista_cards.py plan --repo . --all --category meeting --force
-uv run scripts/deepvista_cards.py push --repo . --all --category meeting --force --apply
+uv run scripts/deepvista_cards.py plan --repo . --all --type meeting --force
+uv run scripts/deepvista_cards.py push --repo . --all --type meeting --force --apply
 ```
+
+**Narrow by `--type`, not `--category`.** The category is the *summary bucket*
+and is much broader than it reads: on a relationship repo `category: meeting`
+holds the people, the companies, the decisions and the corrections too — 111
+entities against 15 of `type: meeting`. A renderer fix that changes only
+meeting bodies re-pushed by category spends a credit each on about a hundred
+cards whose bodies are byte-identical.
 
 Hashing the rendered body instead would make this automatic. It would also
 invalidate every stored hash at once -- a full re-push of the entire store on

--- a/.claude/skills/catchup/reference/deepvista.md
+++ b/.claude/skills/catchup/reference/deepvista.md
@@ -158,6 +158,27 @@ per repo with `deepvista.card_types`.
 The body ends with an HTML comment `<!-- catchup-entity: <id> -->`, so a card
 can be traced back to its entity even if its title is edited in the product.
 
+## A renderer change does not dirty the hash
+
+`content_hash` covers the **entity**, not the rendered card. So a change to
+`render_body` -- a field that was never emitted, a layout fix -- alters what
+every card should say while every entity hashes exactly as before, and `plan`
+reports the whole store as `skip`. The improvement ships to no card at all,
+silently and at no cost, which is the worst combination for noticing.
+
+After a renderer change, re-push the affected slice with `--force`, narrowly,
+because that is one credit per card:
+
+```bash
+uv run scripts/deepvista_cards.py plan --repo . --all --category meeting --force
+uv run scripts/deepvista_cards.py push --repo . --all --category meeting --force --apply
+```
+
+Hashing the rendered body instead would make this automatic. It would also
+invalidate every stored hash at once -- a full re-push of the entire store on
+the next run -- so it is a deliberate decision with a credit bill attached, not
+a tidy-up.
+
 ## The gotcha
 
 **Agent-created cards default to `unconfirmed`, and search filters those out** —

--- a/.claude/skills/catchup/reference/deepvista.md
+++ b/.claude/skills/catchup/reference/deepvista.md
@@ -158,6 +158,63 @@ per repo with `deepvista.card_types`.
 The body ends with an HTML comment `<!-- catchup-entity: <id> -->`, so a card
 can be traced back to its entity even if its title is edited in the product.
 
+## Database rows — a typed edge, and a full replace
+
+A **database** card renders a grid, and what fills it is not an ordinary
+relation. From `upsert_context_card`'s served schema:
+
+> a database's rows MUST be declared this way, because ids passed in
+> `related_context_card_ids` mean only 'generally related' and will NOT appear
+> in the database's grid
+
+The push emits `related_context_card_ids` and nothing else, so every card it
+has ever written is *related to* things and a *row of* nothing. A database card
+pointed at them renders empty — which is exactly what a tracker built by hand
+in the product did, with a working push behind it and no rows in the grid.
+
+`rows` is the command that fixes it, and it is separate from `push` because it
+writes to a different card:
+
+```bash
+uv run scripts/deepvista_cards.py rows --repo . --week 2026-W35            # preview
+uv run scripts/deepvista_cards.py rows --repo . --week 2026-W35 --apply    # read, then write the union
+```
+
+Two properties of the write shape the whole command, and both cut against the
+way the rest of this bridge works.
+
+**Replace semantics, per relation type.** Passing `row_of` sets the database's
+*full* row list — it leaves `RELATED` alone, but every row it does not name is
+gone. So the apply path reads the current rows first and writes back the union.
+A row that maps to none of this repo's entities is never removed, only carried
+through: someone adding a row in the product must not lose it to the next sync.
+`--prune` is the only way a row is removed, and even then only one that maps to
+one of *our* entities that no longer selects.
+
+A truncated read is therefore fatal, not a warning. If the row listing comes
+back at its cap the command refuses to write, because writing back a truncated
+list would delete the remainder — the one failure here that destroys data
+rather than merely not creating it.
+
+**The write lands on the database, not on the row.** Everywhere else the repo
+that owns an entity pushes it; here the payload is the database's row list. Two
+repos writing one database would clobber each other by turns, so **a database
+belongs to exactly one repo's config** (`deepvista.databases`, see
+`reference/config.md`). That is the one documented exception to the ownership
+rule above.
+
+The update sends the database's own `type`, `title`, `description` and `status`
+back alongside the relations. A links-only upsert — `properties` omitted — is
+what re-saved 41 card bodies through an HTML-escaping pass on 2026-09-02;
+sending properties in the same call left them untouched. The database's body is
+short and plain, but the failure mode is the same one.
+
+The preview is local, like `plan`'s: it lists the rows *this repo would
+contribute* and says plainly that it cannot know the current ones without a
+read. It also reports selected entities with no `card_id` — an entity that was
+never pushed cannot be a row, and an empty-looking grid whose real cause is an
+unfinished push is the confusing case worth naming.
+
 ## The gotcha
 
 **Agent-created cards default to `unconfirmed`, and search filters those out** —

--- a/.claude/skills/catchup/scripts/deepvista_cards.py
+++ b/.claude/skills/catchup/scripts/deepvista_cards.py
@@ -403,6 +403,21 @@ def render_body(e, titles, repo_label):
         if blk.get("note"):
             lines.append("")
             lines.append(blk["note"].strip())
+
+        # What is owed and what is still to ask -- the half of a conversation
+        # that EXPIRES. The local summary has rendered these as sub-bullets
+        # since the meetings format was rewritten; this renderer never emitted
+        # them, so every meeting card could say what the conversation was about
+        # and nothing about what it left outstanding. Found by the W35 control
+        # run, when the card-only fund summary came back unable to name a single
+        # follow-up, and open through W36.
+        for label, key in (("Owed", "owed"), ("Ask", "asks")):
+            items = [" ".join(str(i).split()) for i in (blk.get(key) or []) if str(i).strip()]
+            if items:
+                lines.append("")
+                lines.append(f"**{label}:**")
+                lines += [f"- {x}" for x in items]
+
         ev = []
         if blk.get("people"):
             ev.append("People: " + ", ".join(blk["people"]))

--- a/.claude/skills/catchup/scripts/deepvista_cards.py
+++ b/.claude/skills/catchup/scripts/deepvista_cards.py
@@ -36,6 +36,8 @@ Usage:
     deepvista_cards.py push --week 2026-W35 --apply     # explicit MCP write
     deepvista_cards.py plan --all --category meeting
     deepvista_cards.py plan --week 2026-W35 --show-body    # eyeball the markdown
+    deepvista_cards.py rows --week 2026-W35              # which cards would be rows
+    deepvista_cards.py rows --week 2026-W35 --apply      # read rows, write the union
     deepvista_cards.py record --id ray-summit --card-id abc-123  # recovery only
 """
 
@@ -744,6 +746,241 @@ def cmd_push(args, repo, cfg, sdir):
                                   "reinits": client.reinits}}, indent=2))
 
 
+# ------------------------------------------------------------ database rows
+#
+# A database card's rows are a TYPED edge, and nothing else counts. From
+# `upsert_context_card`'s served schema, read 2026-09-09:
+#
+#   "a database's rows MUST be declared this way, because ids passed in
+#    `related_context_card_ids` mean only 'generally related' and will NOT
+#    appear in the database's grid"
+#
+# This bridge emitted only `related_context_card_ids` until now, so every card
+# it has ever pushed is *related to* things and a *row of* nothing -- which is
+# why a database card pointed at them renders an empty grid. That is the whole
+# defect this command exists to fix.
+#
+# Two properties of the write decide its shape, and both cut against the way
+# the rest of this file works:
+#
+#   REPLACE SEMANTICS, PER rel_type. Passing `row_of` sets the database's FULL
+#   row list (and leaves its RELATED links alone). So a write naming only the
+#   rows this repo knows about DELETES every row anyone else added -- a human
+#   in the product, or another repo. The apply path therefore READS the current
+#   rows first and writes back the union. A row that maps to none of our
+#   entities is never removed, only ever carried through.
+#
+#   THE WRITE LANDS ON THE DATABASE, not on the row. Everywhere else here the
+#   repo that owns an entity pushes it; a database written by two repos would
+#   have them clobbering each other's rows by turns. So a database belongs to
+#   exactly one repo's config, and the union above is the guard for the human
+#   case rather than for a second repo.
+
+ROW_SPEC_KEYS = {"card_id", "title", "types", "categories",
+                 "tags_any", "tags_all", "weeks", "$comment"}
+
+
+def row_databases(cfg):
+    """The `deepvista.databases` specs, validated here rather than at the call.
+
+    A typo in a selector is silent at the endpoint -- it selects nothing, the
+    union writes back exactly what was already there, and the grid stays empty
+    with no error anywhere. So the vocabulary is closed and checked locally.
+    """
+    dv = cfg.get("deepvista") or {}
+    specs = dv.get("databases") or []
+    if isinstance(specs, dict):
+        specs = [specs]
+    out = []
+    for i, s in enumerate(specs):
+        if not isinstance(s, dict) or not s.get("card_id"):
+            die(f"deepvista.databases[{i}] needs a card_id -- the id of the "
+                "database card whose rows these are")
+        unknown = set(s) - ROW_SPEC_KEYS
+        if unknown:
+            die(f"deepvista.databases[{i}] ({s['card_id']}) has unknown keys: "
+                f"{', '.join(sorted(unknown))}. Known: {', '.join(sorted(ROW_SPEC_KEYS))}")
+        if s.get("weeks") not in (None, "all", "week"):
+            die(f"deepvista.databases[{i}] weeks must be \"all\" or \"week\", "
+                f"not {s['weeks']!r}")
+        out.append(s)
+    return out
+
+
+def selects_row(e, spec, week=None):
+    """Whether one entity belongs in this database's grid.
+
+    Every clause is a narrowing filter, so a spec with no selectors at all
+    takes the repo's whole store. That is deliberate -- a week database wants
+    exactly that, bounded by `weeks: "week"`.
+    """
+    if spec.get("types") and e.get("type") not in spec["types"]:
+        return False
+    if spec.get("categories") and e.get("category") not in spec["categories"]:
+        return False
+    own = set(e.get("tags") or [])
+    if spec.get("tags_any") and not own & set(spec["tags_any"]):
+        return False
+    if spec.get("tags_all") and not set(spec["tags_all"]) <= own:
+        return False
+    if spec.get("weeks") == "week" and week not in (e.get("weeks") or {}):
+        return False
+    return True
+
+
+def build_rows_plan(args, repo, cfg, sdir):
+    """Local preview: which of this repo's cards would be rows of which database.
+
+    Deliberately local-only, like `plan`. It cannot know the database's CURRENT
+    rows without a read, and says so rather than implying the list it prints is
+    the list the grid would end up with.
+    """
+    ents = load_all(sdir)
+    repo_label = (cfg.get("repo") or {}).get("label") or os.path.basename(repo)
+    specs = row_databases(cfg)
+    if args.database:
+        specs = [s for s in specs if s["card_id"] == args.database]
+        if not specs:
+            die(f"no deepvista.databases entry with card_id {args.database}")
+    if not specs:
+        die("this repo's config declares no deepvista.databases, so there is no "
+            "grid to fill. See reference/deepvista.md.")
+
+    plan = []
+    for s in specs:
+        if s.get("weeks") == "week" and not args.week:
+            die(f"database {s['card_id']} selects its rows by week; pass --week YYYY-WNN")
+        rows, unpushed = [], []
+        for e in sorted(ents, key=lambda x: x["id"]):
+            if not selects_row(e, s, args.week):
+                continue
+            cid = (e.get("deepvista") or {}).get("card_id")
+            (rows if cid else unpushed).append(
+                {"entity_id": e["id"], "card_id": cid} if cid else e["id"])
+        plan.append({
+            "database": s["card_id"],
+            "title": s.get("title"),
+            "weeks": s.get("weeks") or "all",
+            "ours": rows,
+            # An entity with no card cannot be a row. Reported rather than
+            # skipped silently: an empty-looking grid whose cause is an
+            # unfinished push is the confusing case worth naming.
+            "unpushed": unpushed,
+        })
+    return {
+        "endpoint": MCP_ENDPOINT,
+        "repo": repo_label,
+        "week": args.week,
+        "enabled": (cfg.get("deepvista") or {}).get("enabled", False),
+        "databases": plan,
+    }
+
+
+def _row_ids(listing):
+    """Card ids out of a `list_related_context_cards` reply, order preserved."""
+    items = []
+    if isinstance(listing, dict):
+        items = listing.get("cards") or listing.get("hits") or listing.get("results") or []
+    out = []
+    for it in items:
+        cid = (it or {}).get("card_id") or (it or {}).get("id")
+        if cid and cid not in out:
+            out.append(cid)
+    return out
+
+
+def cmd_rows(args, repo, cfg, sdir):
+    """Declare this repo's cards as rows of its database cards.
+
+    Read the current rows, write back the union, and leave anything we did not
+    put there alone. `--prune` is the one way a row is removed, and even then
+    only a row that maps to one of THIS repo's entities that no longer selects.
+    """
+    dv_cfg = cfg.get("deepvista") or {}
+    if not dv_cfg.get("enabled") and not args.force:
+        die("deepvista.enabled is not true in this repo's config; pass --force to row up anyway")
+
+    result = build_rows_plan(args, repo, cfg, sdir)
+    if not args.apply:
+        result["applied"] = False
+        result["next"] = (
+            "No DeepVista call was made. This preview lists only the rows THIS REPO "
+            "would contribute -- it cannot know the database's current rows without "
+            "reading them. Re-run with --apply to read the existing rows and write "
+            "the union.")
+        print(json.dumps(result, indent=2))
+        return
+
+    ents = load_all(sdir)
+    ours_by_card = {(e.get("deepvista") or {}).get("card_id"): e["id"]
+                    for e in ents if (e.get("deepvista") or {}).get("card_id")}
+
+    npx = resolve_npx(args.npx)
+    if not npx:
+        die(f"no npx {MCP_MIN_NPX}+ found to run the mcp-remote proxy -- `brew install node`, "
+            "or pass --npx /path/to/npx")
+    client = McpClient(npx, timeout=args.timeout)
+    applied = []
+    try:
+        for entry in result["databases"]:
+            db = entry["database"]
+            listing = client.call("list_related_context_cards", card_id=db,
+                                  relation_type="row_of", limit=args.limit)
+            if isinstance(listing, dict) and listing.get("_error"):
+                die(f"list_related_context_cards for {db}: {listing['_error']}")
+            existing = _row_ids(listing)
+            if len(existing) >= args.limit:
+                die(f"database {db} already lists {len(existing)} rows at the read "
+                    f"limit of {args.limit}; raise --limit rather than writing back a "
+                    "truncated row list, which would delete the remainder")
+
+            want = [r["card_id"] for r in entry["ours"]]
+            dropped = []
+            if args.prune:
+                # Only ever a row we recognise as one of our own entities that
+                # no longer selects. A row belonging to nobody we know is not
+                # ours to remove, however stale it looks.
+                keep = []
+                for cid in existing:
+                    if cid in ours_by_card and cid not in want:
+                        dropped.append({"card_id": cid, "entity_id": ours_by_card[cid]})
+                    else:
+                        keep.append(cid)
+                existing = keep
+            merged = existing + [c for c in want if c not in existing]
+            added = [c for c in want if c not in existing]
+
+            if not added and not dropped:
+                applied.append({"database": db, "written": False, "reason": "already current",
+                                "rows": len(merged)})
+                continue
+
+            # Echo the card's own properties back with the relations. A
+            # links-only upsert -- `properties` omitted -- is what re-saved 41
+            # card bodies through an HTML-escaping pass on 2026-09-02; sending
+            # properties in the same call left them untouched. The database's
+            # body is short and plain, but the failure mode is the same one.
+            card = client.call("read_context_card", card_id=db)
+            if not isinstance(card, dict) or card.get("_error") or not card.get("id"):
+                die(f"read_context_card for {db}: "
+                    f"{(card or {}).get('_error', 'no card returned')}")
+            props = {k: card.get(k) for k in ("type", "title", "description", "status")
+                     if card.get(k) is not None}
+            response = client.call(
+                "upsert_context_card", card_id=db, properties=props,
+                relations=[{"card_id": c, "rel_type": "row_of"} for c in merged])
+            if isinstance(response, dict) and response.get("_error"):
+                die(f"upsert_context_card rows for {db}: {response['_error']}")
+            applied.append({"database": db, "written": True, "rows": len(merged),
+                            "added": added, "dropped": dropped,
+                            "carried_through": len(existing) - len(added)})
+    finally:
+        client.close()
+    print(json.dumps({"applied": True, "databases": applied,
+                      "session": {"handshake_attempts": client.attempts,
+                                  "reinits": client.reinits}}, indent=2))
+
+
 def _mentions(text, entity, week=None):
     """Whether a summary actually refers to this entity.
 
@@ -1088,6 +1325,20 @@ def main():
     p.add_argument("--npx", default=None, help="npx to run the mcp-remote proxy with")
     p.add_argument("--timeout", type=int, default=90, help="seconds to wait per call")
     p.set_defaults(fn=cmd_push)
+
+    p = sub.add_parser("rows", parents=[common],
+                       help="declare this repo's cards as ROWS of its database cards")
+    p.add_argument("--week", help="required by a database whose spec says weeks: \"week\"")
+    p.add_argument("--database", default=None, help="only this database card id")
+    p.add_argument("--apply", action="store_true",
+                   help="read the current rows and write the union; omitted means local preview")
+    p.add_argument("--prune", action="store_true",
+                   help="also REMOVE rows that are this repo's entities and no longer select")
+    p.add_argument("--force", action="store_true", help="row up even if deepvista.enabled is false")
+    p.add_argument("--limit", type=int, default=500, help="row-read cap; a full read is required to write safely")
+    p.add_argument("--npx", default=None, help="npx to run the mcp-remote proxy with")
+    p.add_argument("--timeout", type=int, default=90, help="seconds to wait per call")
+    p.set_defaults(fn=cmd_rows)
 
     p = sub.add_parser("record", parents=[common], help="write back the card id after an MCP call")
     p.add_argument("--id", required=True)

--- a/.claude/skills/catchup/scripts/deepvista_cards.py
+++ b/.claude/skills/catchup/scripts/deepvista_cards.py
@@ -561,6 +561,13 @@ def build_plan(args, repo, cfg, sdir):
         die("pass --week YYYY-WNN or --all")
     if args.category:
         ents = [e for e in ents if e.get("category") == args.category]
+    # `category` is the summary bucket and is much broader than it reads: on a
+    # relationship repo `meeting` holds the people, the companies, the decisions
+    # and the corrections too -- 111 entities where `type: meeting` is 15. So a
+    # renderer fix that only changes meeting BODIES needs the type, or the
+    # --force re-push spends a credit each on a hundred cards it does not alter.
+    if getattr(args, "type", None):
+        ents = [e for e in ents if e.get("type") == args.type]
     if args.status:
         ents = [e for e in ents if e.get("status") == args.status]
 
@@ -1059,6 +1066,8 @@ def main():
     p.add_argument("--week")
     p.add_argument("--all", action="store_true")
     p.add_argument("--category", choices=CATEGORY_ORDER)
+    p.add_argument("--type", choices=sorted(CARD_TYPE),
+                   help="entity type — narrower than --category, which is the summary bucket")
     p.add_argument("--status")
     p.add_argument("--force", action="store_true", help="re-push even if unchanged")
     p.add_argument("--show-body", action="store_true", help="full markdown, not truncated")
@@ -1096,6 +1105,8 @@ def main():
     p.add_argument("--week")
     p.add_argument("--all", action="store_true")
     p.add_argument("--category", choices=CATEGORY_ORDER)
+    p.add_argument("--type", choices=sorted(CARD_TYPE),
+                   help="entity type — narrower than --category, which is the summary bucket")
     p.add_argument("--status")
     p.add_argument("--limit", type=int, default=0)
     p.add_argument("--force", action="store_true", help="re-push unchanged cards or override disabled config")

--- a/.claude/skills/catchup/scripts/deepvista_cards.py
+++ b/.claude/skills/catchup/scripts/deepvista_cards.py
@@ -331,7 +331,7 @@ def card_status(dv_cfg):
     return want
 
 
-def render_body(e, titles, repo_label):
+def render_body(e, titles, repo_label, by_id=None):
     """The card's markdown body.
 
     Carries the full week-by-week timeline, not just the current summary. That is
@@ -339,6 +339,13 @@ def render_body(e, titles, repo_label):
     that the cards should hold enough for DeepVista to compose a catchup itself.
     A card that only said "here is the latest" could not.
     """
+    by_id = by_id or {}
+
+    def name(eid):
+        """An entity id as a reader's name. Falls back to the id itself, which
+        is what a card said for attendees before they were rendered at all."""
+        return by_id.get(eid) or eid
+
     weeks = sorted(e.get("weeks") or {})
     lines = [e.get("summary", "").strip(), ""]
 
@@ -384,6 +391,16 @@ def render_body(e, titles, repo_label):
                 bits.append(f"{wt['commits']} commits")
             lines.append("")
             lines.append("**Weight:** " + " · ".join(bits))
+        # What became of the theme, and what it cost or bought. A theme card
+        # that carries `moved` and not `disposition` says what happened and not
+        # whether it stuck -- and `dropped` is the single most useful thing a
+        # later reader can know about a week's theme.
+        if blk.get("disposition"):
+            lines.append("")
+            lines.append(f"**Disposition:** {blk['disposition']}")
+        if blk.get("consequence"):
+            lines.append("")
+            lines.append(f"**Consequence:** {str(blk['consequence']).strip()}")
         if blk.get("evidence"):
             lines.append("")
             lines.append("**Evidence:**")
@@ -391,8 +408,10 @@ def render_body(e, titles, repo_label):
 
         if blk.get("claim"):
             grade = blk.get("grade")
+            rank = blk.get("rank")
             lines.append(f"**Claim:** {blk['claim'].strip()}"
-                         + (f"  *[{grade}]*" if grade else ""))
+                         + (f"  *[{grade}]*" if grade else "")
+                         + (f"  *[rank {rank}]*" if rank else ""))
         if blk.get("so_what"):
             lines.append("")
             lines.append(blk["so_what"].strip())
@@ -419,10 +438,18 @@ def render_body(e, titles, repo_label):
                 lines += [f"- {x}" for x in items]
 
         ev = []
+        # Who was in the room. `attendees` is the canonical field -- the one
+        # contact_state derives "have I met this person" from -- and it never
+        # reached the card, so 4 of the fund's 15 meeting cards named nobody at
+        # all and the rest named only whoever also appeared in `people`.
+        if blk.get("attendees"):
+            ev.append("In the room: " + ", ".join(name(a) for a in blk["attendees"]))
         if blk.get("people"):
             ev.append("People: " + ", ".join(blk["people"]))
         if blk.get("prs"):
             ev.append("PRs: " + ", ".join(f"#{p}" for p in blk["prs"]))
+        if blk.get("open_prs"):
+            ev.append("Still open: " + ", ".join(f"#{p}" for p in blk["open_prs"]))
         if blk.get("commits"):
             ev.append("Commits: " + ", ".join(blk["commits"][:8])
                       + (f" (+{len(blk['commits']) - 8} more)" if len(blk["commits"]) > 8 else ""))
@@ -433,10 +460,20 @@ def render_body(e, titles, repo_label):
             lines += [f"- {x}" for x in ev]
         lines.append("")
 
+    if e.get("urls"):
+        lines.append("## Published")
+        lines.append("")
+        for u in e["urls"]:
+            if isinstance(u, dict) and u.get("url"):
+                lines.append(f"- [{u.get('label') or u['url']}]({u['url']})")
+            elif u:
+                lines.append(f"- {u}")
+        lines.append("")
+
     if e.get("links"):
         lines.append("## Related")
         lines.append("")
-        lines += [f"- `{l}`" for l in e["links"]]
+        lines += [f"- {name(l)} (`{l}`)" for l in e["links"]]
         lines.append("")
 
     lines.append(f"<!-- catchup-entity: {e['id']} -->")
@@ -567,7 +604,7 @@ def build_plan(args, repo, cfg, sdir):
     # renderer fix that only changes meeting BODIES needs the type, or the
     # --force re-push spends a credit each on a hundred cards it does not alter.
     if getattr(args, "type", None):
-        ents = [e for e in ents if e.get("type") == args.type]
+        ents = [e for e in ents if e.get("type") in set(args.type)]
     if args.status:
         ents = [e for e in ents if e.get("status") == args.status]
 
@@ -581,6 +618,7 @@ def build_plan(args, repo, cfg, sdir):
     card_of = {x["id"]: (x.get("deepvista") or {}).get("card_id")
                for x in all_ents if (x.get("deepvista") or {}).get("card_id")}
 
+    by_id = {x["id"]: x.get("title") for x in all_ents if x.get("title")}
     plan, counts = [], {"create": 0, "update": 0, "skip": 0}
     for e in sorted(ents, key=lambda x: (CATEGORY_ORDER.index(x.get("category", "other"))
                                          if x.get("category") in CATEGORY_ORDER else 9, x["id"])):
@@ -626,7 +664,7 @@ def build_plan(args, repo, cfg, sdir):
             "card": {
                 "type": type_map.get(e.get("type"), "note"),
                 "title": e["title"],
-                "description": render_body(e, titles, repo_label),
+                "description": render_body(e, titles, repo_label, by_id),
                 "tags": build_tags(e, cfg, repo_label, all_ents),
                 "status": card_status(dv_cfg),
             },
@@ -973,7 +1011,8 @@ def cmd_fetch(args, repo, cfg, sdir):
                 continue
             body = card.get("description") or ""
             tracer = _tracer_state(body, e["id"])
-            state = _body_state(body, render_body(e, titles, repo_label), tracer)
+            state = _body_state(body, render_body(e, titles, repo_label,
+                                     {x['id']: x.get('title') for x in all_ents if x.get('title')}), tracer)
             cards.append({
                 "entity_id": e["id"],
                 "entity_type": e.get("type"),
@@ -1066,8 +1105,9 @@ def main():
     p.add_argument("--week")
     p.add_argument("--all", action="store_true")
     p.add_argument("--category", choices=CATEGORY_ORDER)
-    p.add_argument("--type", choices=sorted(CARD_TYPE),
-                   help="entity type — narrower than --category, which is the summary bucket")
+    p.add_argument("--type", choices=sorted(CARD_TYPE), nargs="+", metavar="TYPE",
+                   help="one or more entity types — narrower than --category, which is "
+                        "the summary bucket. A renderer change usually touches several.")
     p.add_argument("--status")
     p.add_argument("--force", action="store_true", help="re-push even if unchanged")
     p.add_argument("--show-body", action="store_true", help="full markdown, not truncated")
@@ -1105,8 +1145,9 @@ def main():
     p.add_argument("--week")
     p.add_argument("--all", action="store_true")
     p.add_argument("--category", choices=CATEGORY_ORDER)
-    p.add_argument("--type", choices=sorted(CARD_TYPE),
-                   help="entity type — narrower than --category, which is the summary bucket")
+    p.add_argument("--type", choices=sorted(CARD_TYPE), nargs="+", metavar="TYPE",
+                   help="one or more entity types — narrower than --category, which is "
+                        "the summary bucket. A renderer change usually touches several.")
     p.add_argument("--status")
     p.add_argument("--limit", type=int, default=0)
     p.add_argument("--force", action="store_true", help="re-push unchanged cards or override disabled config")

--- a/.claude/skills/catchup/scripts/deploy.py
+++ b/.claude/skills/catchup/scripts/deploy.py
@@ -146,21 +146,74 @@ def is_ignored(repo, rel):
     return p.returncode == 0
 
 
+def fetch_origin(repo):
+    """Refresh origin's refs, and SAY SO when it cannot.
+
+    This was best-effort and silent, which is the worst shape for it: a fetch
+    that fails leaves `origin/<default>` wherever it was last time, the new
+    branch is cut from there, and nothing in the output says the base is old.
+    Two prepared re-pushes were planned against a 28-commit-stale store before
+    anyone noticed -- and it was noticed from a diff, not from this tool.
+    """
+    p = subprocess.run(["git", "-C", repo, "fetch", "-q", "origin"],
+                       capture_output=True, text=True)
+    if p.returncode == 0:
+        return True
+    # git's failure is several lines and the LAST one is a sentence fragment
+    # ("and the repository exists."). The `fatal:` line is the one that says
+    # what went wrong.
+    lines = [l.strip() for l in (p.stderr or p.stdout).splitlines() if l.strip()]
+    detail = next((l for l in lines if l.startswith("fatal:")), lines[0] if lines else "")
+    print(f"  WARNING: could not fetch origin in {repo}"
+          + (f" -- {detail}" if detail else ""))
+    print("           Its refs may be stale, so a new branch would be cut from an old base.")
+    return False
+
+
+def report_base(repo, path):
+    """How far behind origin's default branch this worktree sits.
+
+    Printed on BOTH paths -- created and reused -- because a reused worktree
+    keeps whatever base it was made with, and re-running a deploy into one is
+    exactly how a stale base survives the fetch that would have caught it.
+    """
+    default = default_branch(repo)
+    if not default:
+        return
+    ref = f"origin/{default}"
+    if not git(repo, "rev-parse", "--verify", "-q", f"refs/remotes/{ref}", ok_fail=True):
+        return
+    behind = git(path, "rev-list", "--count", f"HEAD..{ref}", ok_fail=True)
+    if behind is None:
+        return
+    if behind == "0":
+        print(f"  base: current with {ref}")
+        return
+    print(f"  WARNING: this worktree is {behind} commit(s) behind {ref}.")
+    print("           Anything planned from it -- a push, a summary, a week's stats --")
+    print("           reads a store that is missing those commits.")
+    print(f"           git -C {path} fetch origin {default} && git -C {path} rebase {ref}")
+
+
 def ensure_worktree(repo, name):
     """A worktree of `repo` at .claude/worktrees/<name> on branch <name>.
 
     Reused if it already exists. Otherwise created from origin's default branch
-    when that ref is known (after a best-effort fetch), else from HEAD -- so a
+    when that ref is known (after a fetch that reports its own failure),
+    else from HEAD -- so a
     deploy starts from what main actually is, not from wherever the primary
     checkout happened to be left.
     """
     path = os.path.join(repo, WORKTREES_REL, name)
+    # Fetch FIRST, and before the reuse check, so both paths judge staleness
+    # against refs that were just refreshed rather than against last week's.
+    fetch_origin(repo)
     if os.path.isdir(path) and os.path.exists(os.path.join(path, ".git")):
         print(f"worktree: using existing {os.path.relpath(path, repo)} "
               f"(branch {current_branch(path) or 'DETACHED'})")
+        report_base(repo, path)
         return path
     os.makedirs(os.path.dirname(path), exist_ok=True)
-    subprocess.run(["git", "-C", repo, "fetch", "-q", "origin"], capture_output=True)
     if git(repo, "rev-parse", "--verify", "-q", f"refs/heads/{name}", ok_fail=True):
         git(repo, "worktree", "add", path, name)
         print(f"worktree: checked out existing branch {name} at {os.path.relpath(path, repo)}")
@@ -178,6 +231,7 @@ def ensure_worktree(repo, name):
             ok_fail=True) else "HEAD"
         git(repo, "worktree", "add", "-b", name, path, base)
         print(f"worktree: created {os.path.relpath(path, repo)} on new branch {name} from {base}")
+    report_base(repo, path)
     if not is_ignored(repo, os.path.join(WORKTREES_REL, name)):
         print(f"  WARNING: {WORKTREES_REL}/ is not ignored in {repo}, so the worktree itself")
         print("           shows up as an untracked directory in the main checkout.")

--- a/.claude/skills/catchup/scripts/entities.py
+++ b/.claude/skills/catchup/scripts/entities.py
@@ -228,11 +228,19 @@ def load_all(sdir):
 
 
 def content_hash(e):
-    """Hash of everything a DeepVista card would carry.
+    """Hash of the ENTITY a DeepVista card is rendered from -- not of the card.
 
     The sync compares this to what it last pushed, so an unchanged entity costs
     no API call and no credit. Deliberately excludes the `deepvista` block, which
     the sync itself writes -- otherwise every push would dirty its own input.
+
+    The gap to know about: a change to `render_body` alters what the card says
+    without touching the entity, so every already-pushed card hashes as `skip`
+    and the improvement never ships. Re-push the affected category with
+    `--force` after a renderer change -- narrowly, since that is a credit per
+    card. Hashing the rendered body instead would make this automatic and would
+    also invalidate every stored hash at once, which is a full re-push of every
+    card in the store; worth doing deliberately, not as a side effect.
     """
     payload = {k: v for k, v in e.items()
                if k not in ("deepvista", "_path", "updated_at")}

--- a/.claude/skills/catchup/tests/test_deepvista_cards.py
+++ b/.claude/skills/catchup/tests/test_deepvista_cards.py
@@ -92,6 +92,177 @@ class DeepVistaPushTest(unittest.TestCase):
         self.assertEqual(calls[-1], ("close",))
 
 
+class DeepVistaRowsTest(unittest.TestCase):
+    """Rows are a typed edge with REPLACE semantics, so the dangerous case is
+    not a failed write -- it is a successful one that silently deletes rows
+    this repo never knew about."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.repo = Path(self.tmp.name)
+        self.store = self.repo / "catchup" / "entities"
+        self.store.mkdir(parents=True)
+        self.write("acme", type="org", tags=["portfolio"], card_id="card-acme")
+        self.write("beta", type="org", tags=["watchlist"], card_id="card-beta")
+        self.write("gamma", type="org", tags=["portfolio"], card_id=None)
+        self.cfg = {
+            "repo": {"label": "fixture"},
+            "deepvista": {
+                "enabled": True,
+                "databases": [{"card_id": "db-1", "types": ["org"],
+                               "tags_any": ["portfolio"]}],
+            },
+        }
+
+    def write(self, eid, type, tags, card_id):
+        (self.store / f"{eid}.json").write_text(json.dumps({
+            "id": eid, "type": type, "title": eid.title(), "summary": "s",
+            "category": "orgs", "status": "active", "tags": tags, "links": [],
+            "weeks": {"2026-W35": {"claim": "c"}},
+            "deepvista": {"card_id": card_id, "synced_at": None, "content_hash": None},
+        }))
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def args(self, **kw):
+        base = dict(week="2026-W35", database=None, apply=False, prune=False,
+                    force=False, limit=500, npx=None, timeout=1)
+        base.update(kw)
+        return argparse.Namespace(**base)
+
+    def run_cmd(self, args, client=None):
+        out = io.StringIO()
+        ctx = mock.patch.object(deepvista_cards, "McpClient",
+                                client or mock.Mock(side_effect=AssertionError("opened MCP")))
+        with mock.patch.object(deepvista_cards, "resolve_npx", return_value="/npx"), ctx:
+            with contextlib.redirect_stdout(out):
+                deepvista_cards.cmd_rows(args, str(self.repo), self.cfg, str(self.store))
+        return json.loads(out.getvalue())
+
+    def test_preview_is_local_and_reports_unpushed(self):
+        result = self.run_cmd(self.args())
+        self.assertFalse(result["applied"])
+        entry = result["databases"][0]
+        self.assertEqual([r["card_id"] for r in entry["ours"]], ["card-acme"])
+        # Selected by tag but never pushed, so it cannot be a row -- and an
+        # empty-looking grid caused by an unfinished push is worth naming.
+        self.assertEqual(entry["unpushed"], ["gamma"])
+
+    def test_apply_writes_the_union_and_never_drops_a_foreign_row(self):
+        seen = []
+
+        class FakeClient:
+            attempts, reinits = 1, 0
+
+            def __init__(self, npx, timeout):
+                pass
+
+            def call(self, tool, **kw):
+                seen.append((tool, kw))
+                if tool == "list_related_context_cards":
+                    # A row a human added in the product, and one of ours.
+                    return {"cards": [{"card_id": "human-row"}, {"card_id": "card-acme"}]}
+                if tool == "read_context_card":
+                    return {"id": "db-1", "type": "database", "title": "DB",
+                            "description": "body", "status": "active"}
+                return {"id": "db-1"}
+
+            def close(self):
+                pass
+
+        result = self.run_cmd(self.args(apply=True), client=FakeClient)
+        self.assertTrue(result["applied"])
+        # card-acme was already a row and nothing else selects, so there is
+        # nothing to add and no credit to spend.
+        self.assertFalse(result["databases"][0]["written"])
+        self.assertEqual(result["databases"][0]["reason"], "already current")
+        self.assertNotIn("upsert_context_card", [t for t, _ in seen])
+
+    def test_apply_sends_properties_with_the_relations(self):
+        seen = []
+
+        class FakeClient:
+            attempts, reinits = 1, 0
+
+            def __init__(self, npx, timeout):
+                pass
+
+            def call(self, tool, **kw):
+                seen.append((tool, kw))
+                if tool == "list_related_context_cards":
+                    return {"cards": [{"card_id": "human-row"}]}
+                if tool == "read_context_card":
+                    return {"id": "db-1", "type": "database", "title": "DB",
+                            "description": "body", "status": "active"}
+                return {"id": "db-1"}
+
+            def close(self):
+                pass
+
+        result = self.run_cmd(self.args(apply=True), client=FakeClient)
+        upsert = [kw for t, kw in seen if t == "upsert_context_card"][0]
+        rows = [r["card_id"] for r in upsert["relations"]]
+        # The human's row survives, ours joins it, and every edge is typed.
+        self.assertEqual(rows, ["human-row", "card-acme"])
+        self.assertTrue(all(r["rel_type"] == "row_of" for r in upsert["relations"]))
+        # Properties travel WITH the relations: a links-only upsert re-saved 41
+        # card bodies through an HTML-escaping pass on 2026-09-02.
+        self.assertEqual(upsert["properties"]["description"], "body")
+        self.assertTrue(result["databases"][0]["written"])
+
+    def test_prune_removes_only_our_own_deselected_rows(self):
+        class FakeClient:
+            attempts, reinits = 1, 0
+
+            def __init__(self, npx, timeout):
+                pass
+
+            def call(self, tool, **kw):
+                if tool == "list_related_context_cards":
+                    # card-beta is ours (watchlist, so no longer selected);
+                    # human-row is nobody's.
+                    return {"cards": [{"card_id": "human-row"},
+                                      {"card_id": "card-beta"}]}
+                if tool == "read_context_card":
+                    return {"id": "db-1", "type": "database", "title": "DB",
+                            "description": "body", "status": "active"}
+                return {"id": "db-1"}
+
+            def close(self):
+                pass
+
+        result = self.run_cmd(self.args(apply=True, prune=True), client=FakeClient)
+        entry = result["databases"][0]
+        self.assertEqual([d["entity_id"] for d in entry["dropped"]], ["beta"])
+        self.assertEqual(entry["added"], ["card-acme"])
+
+    def test_a_truncated_row_read_refuses_to_write(self):
+        class FakeClient:
+            attempts, reinits = 1, 0
+
+            def __init__(self, npx, timeout):
+                pass
+
+            def call(self, tool, **kw):
+                if tool == "list_related_context_cards":
+                    return {"cards": [{"card_id": f"r{i}"} for i in range(3)]}
+                return {"id": "db-1"}
+
+            def close(self):
+                pass
+
+        # Writing back a truncated row list would delete the remainder, so the
+        # read hitting its cap has to be fatal rather than merely noted.
+        with self.assertRaises(SystemExit):
+            self.run_cmd(self.args(apply=True, limit=3), client=FakeClient)
+
+    def test_unknown_selector_key_fails_locally(self):
+        self.cfg["deepvista"]["databases"] = [{"card_id": "db-1", "tags": ["oops"]}]
+        with self.assertRaises(SystemExit):
+            deepvista_cards.row_databases(self.cfg)
+
+
 class DeepVistaRegistrationTest(unittest.TestCase):
     def test_repository_mcp_config_does_not_register_deepvista(self):
         root = Path(__file__).resolve().parents[4]

--- a/.claude/skills/catchup/tests/test_deepvista_cards.py
+++ b/.claude/skills/catchup/tests/test_deepvista_cards.py
@@ -137,6 +137,55 @@ class DeepVistaCardBodyTest(unittest.TestCase):
         self.assertNotIn("**Ask:**", body)
 
 
+class DeepVistaTechFieldsTest(unittest.TestCase):
+    """The tech lane had the same defect as meetings, and more of it.
+
+    A theme card carried what MOVED and never whether it stuck; a concept card
+    carried a claim and never its rank; and PRs still open, where an entity is
+    published, and who was in the room reached no card at all.
+    """
+
+    def test_theme_carries_disposition_and_consequence(self):
+        e = {"id": "t", "type": "theme", "title": "T", "summary": "s",
+             "category": "technical", "status": "active",
+             "weeks": {"2026-W36": {"moved": "Rebuilt the ladder.",
+                                    "disposition": "dropped",
+                                    "consequence": "Cost a week and bought nothing."}}}
+        body = deepvista_cards.render_body(e, {}, "fixture")
+        self.assertIn("**Disposition:** dropped", body)
+        self.assertIn("**Consequence:** Cost a week and bought nothing.", body)
+
+    def test_concept_claim_carries_its_rank_beside_its_grade(self):
+        e = {"id": "c", "type": "concept", "title": "C", "summary": "s",
+             "category": "technical", "status": "active",
+             "weeks": {"2026-W36": {"claim": "A cache hit is a validated computation.",
+                                    "grade": "measured", "rank": 2}}}
+        body = deepvista_cards.render_body(e, {}, "fixture")
+        self.assertIn("*[measured]*", body)
+        self.assertIn("*[rank 2]*", body)
+
+    def test_attendees_render_as_names_and_open_prs_as_still_open(self):
+        e = {"id": "m", "type": "meeting", "title": "M", "summary": "s",
+             "category": "meeting", "status": "active",
+             "links": ["dana-lee"],
+             "weeks": {"2026-W36": {"attendees": ["dana-lee", "unknown-id"],
+                                    "prs": ["12"], "open_prs": ["13"]}}}
+        body = deepvista_cards.render_body(e, {}, "fixture", {"dana-lee": "Dana Lee"})
+        self.assertIn("In the room: Dana Lee, unknown-id", body)   # id is the fallback
+        self.assertIn("Still open: #13", body)
+        # Related resolves the same way, so a card reads as names not slugs.
+        self.assertIn("- Dana Lee (`dana-lee`)", body)
+
+    def test_published_urls_reach_the_card(self):
+        e = {"id": "p", "type": "thread", "title": "P", "summary": "s",
+             "category": "technical", "status": "active",
+             "urls": [{"label": "index", "url": "https://example.com/x/"}],
+             "weeks": {"2026-W36": {"note": "n"}}}
+        body = deepvista_cards.render_body(e, {}, "fixture")
+        self.assertIn("## Published", body)
+        self.assertIn("- [index](https://example.com/x/)", body)
+
+
 class DeepVistaTypeFilterTest(unittest.TestCase):
     """`category` is the summary bucket, not the entity type.
 
@@ -164,11 +213,18 @@ class DeepVistaTypeFilterTest(unittest.TestCase):
         self.tmp.cleanup()
 
     def test_type_narrows_within_a_category(self):
-        args = argparse.Namespace(week=None, all=True, category="meeting", type="meeting",
+        args = argparse.Namespace(week=None, all=True, category="meeting", type=["meeting"],
                                   status=None, limit=0, force=True, show_body=True,
                                   include_skipped=False)
         result = deepvista_cards.build_plan(args, str(self.repo), self.cfg, str(self.store))
         self.assertEqual([i["entity_id"] for i in result["plan"]], ["m1"])
+
+    def test_several_types_at_once(self):
+        args = argparse.Namespace(week=None, all=True, category=None, type=["meeting", "org"],
+                                  status=None, limit=0, force=True, show_body=True,
+                                  include_skipped=False)
+        result = deepvista_cards.build_plan(args, str(self.repo), self.cfg, str(self.store))
+        self.assertEqual(sorted(i["entity_id"] for i in result["plan"]), ["m1", "o1"])
 
     def test_category_alone_still_takes_the_whole_bucket(self):
         args = argparse.Namespace(week=None, all=True, category="meeting", type=None,

--- a/.claude/skills/catchup/tests/test_deepvista_cards.py
+++ b/.claude/skills/catchup/tests/test_deepvista_cards.py
@@ -137,6 +137,47 @@ class DeepVistaCardBodyTest(unittest.TestCase):
         self.assertNotIn("**Ask:**", body)
 
 
+class DeepVistaTypeFilterTest(unittest.TestCase):
+    """`category` is the summary bucket, not the entity type.
+
+    On a relationship repo `category: meeting` holds the people, companies,
+    decisions and corrections as well -- 111 entities where `type: meeting` is
+    15. A renderer fix that only changes meeting bodies needs the type, or the
+    --force re-push spends a credit each on a hundred unchanged cards.
+    """
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.repo = Path(self.tmp.name)
+        self.store = self.repo / "catchup" / "entities"
+        self.store.mkdir(parents=True)
+        for eid, etype in (("m1", "meeting"), ("p1", "person"), ("o1", "org")):
+            (self.store / f"{eid}.json").write_text(json.dumps({
+                "id": eid, "type": etype, "title": eid, "summary": "s",
+                "category": "meeting", "status": "active", "tags": [], "links": [],
+                "weeks": {"2026-W35": {"note": "n"}},
+                "deepvista": {"card_id": f"card-{eid}", "content_hash": None},
+            }))
+        self.cfg = {"repo": {"label": "fixture"}, "deepvista": {"enabled": True}}
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_type_narrows_within_a_category(self):
+        args = argparse.Namespace(week=None, all=True, category="meeting", type="meeting",
+                                  status=None, limit=0, force=True, show_body=True,
+                                  include_skipped=False)
+        result = deepvista_cards.build_plan(args, str(self.repo), self.cfg, str(self.store))
+        self.assertEqual([i["entity_id"] for i in result["plan"]], ["m1"])
+
+    def test_category_alone_still_takes_the_whole_bucket(self):
+        args = argparse.Namespace(week=None, all=True, category="meeting", type=None,
+                                  status=None, limit=0, force=True, show_body=True,
+                                  include_skipped=False)
+        result = deepvista_cards.build_plan(args, str(self.repo), self.cfg, str(self.store))
+        self.assertEqual(len(result["plan"]), 3)
+
+
 class DeepVistaRegistrationTest(unittest.TestCase):
     def test_repository_mcp_config_does_not_register_deepvista(self):
         root = Path(__file__).resolve().parents[4]

--- a/.claude/skills/catchup/tests/test_deepvista_cards.py
+++ b/.claude/skills/catchup/tests/test_deepvista_cards.py
@@ -92,6 +92,51 @@ class DeepVistaPushTest(unittest.TestCase):
         self.assertEqual(calls[-1], ("close",))
 
 
+class DeepVistaCardBodyTest(unittest.TestCase):
+    def test_meeting_card_carries_what_is_owed_and_still_to_ask(self):
+        """The half of a conversation that expires.
+
+        The local summary has rendered these as sub-bullets since the meetings
+        format was rewritten; the card renderer never emitted them, so the W35
+        control's card-only summary could say what every conversation was about
+        and not one thing it left outstanding.
+        """
+        entity = {
+            "id": "meeting-acme",
+            "type": "meeting",
+            "title": "Acme — Dana",
+            "summary": "First call.",
+            "category": "meetings",
+            "status": "active",
+            "weeks": {"2026-W35": {
+                "date": "2026-08-27",
+                "note": "They walked through the pipeline.",
+                "owed": ["Intro to the   infra lead", "Send the memo"],
+                "asks": ["Their churn number"],
+                "people": ["dana"],
+            }},
+        }
+        body = deepvista_cards.render_body(entity, {"meetings": "Meetings"}, "fixture")
+        self.assertIn("**Owed:**", body)
+        self.assertIn("- Intro to the infra lead", body)   # whitespace collapsed
+        self.assertIn("- Send the memo", body)
+        self.assertIn("**Ask:**", body)
+        self.assertIn("- Their churn number", body)
+        # The note is the synthesis and still leads; the actions follow it.
+        self.assertLess(body.index("They walked through"), body.index("**Owed:**"))
+        self.assertLess(body.index("**Owed:**"), body.index("**Ask:**"))
+
+    def test_an_entity_with_neither_gains_no_empty_headings(self):
+        entity = {
+            "id": "concept-x", "type": "concept", "title": "X", "summary": "s",
+            "category": "technical", "status": "active",
+            "weeks": {"2026-W35": {"claim": "c", "owed": [], "asks": None}},
+        }
+        body = deepvista_cards.render_body(entity, {}, "fixture")
+        self.assertNotIn("**Owed:**", body)
+        self.assertNotIn("**Ask:**", body)
+
+
 class DeepVistaRegistrationTest(unittest.TestCase):
     def test_repository_mcp_config_does_not_register_deepvista(self):
         root = Path(__file__).resolve().parents[4]

--- a/.claude/skills/rollup/scripts/deploy.py
+++ b/.claude/skills/rollup/scripts/deploy.py
@@ -146,21 +146,74 @@ def is_ignored(repo, rel):
     return p.returncode == 0
 
 
+def fetch_origin(repo):
+    """Refresh origin's refs, and SAY SO when it cannot.
+
+    This was best-effort and silent, which is the worst shape for it: a fetch
+    that fails leaves `origin/<default>` wherever it was last time, the new
+    branch is cut from there, and nothing in the output says the base is old.
+    Two prepared re-pushes were planned against a 28-commit-stale store before
+    anyone noticed -- and it was noticed from a diff, not from this tool.
+    """
+    p = subprocess.run(["git", "-C", repo, "fetch", "-q", "origin"],
+                       capture_output=True, text=True)
+    if p.returncode == 0:
+        return True
+    # git's failure is several lines and the LAST one is a sentence fragment
+    # ("and the repository exists."). The `fatal:` line is the one that says
+    # what went wrong.
+    lines = [l.strip() for l in (p.stderr or p.stdout).splitlines() if l.strip()]
+    detail = next((l for l in lines if l.startswith("fatal:")), lines[0] if lines else "")
+    print(f"  WARNING: could not fetch origin in {repo}"
+          + (f" -- {detail}" if detail else ""))
+    print("           Its refs may be stale, so a new branch would be cut from an old base.")
+    return False
+
+
+def report_base(repo, path):
+    """How far behind origin's default branch this worktree sits.
+
+    Printed on BOTH paths -- created and reused -- because a reused worktree
+    keeps whatever base it was made with, and re-running a deploy into one is
+    exactly how a stale base survives the fetch that would have caught it.
+    """
+    default = default_branch(repo)
+    if not default:
+        return
+    ref = f"origin/{default}"
+    if not git(repo, "rev-parse", "--verify", "-q", f"refs/remotes/{ref}", ok_fail=True):
+        return
+    behind = git(path, "rev-list", "--count", f"HEAD..{ref}", ok_fail=True)
+    if behind is None:
+        return
+    if behind == "0":
+        print(f"  base: current with {ref}")
+        return
+    print(f"  WARNING: this worktree is {behind} commit(s) behind {ref}.")
+    print("           Anything planned from it -- a push, a summary, a week's stats --")
+    print("           reads a store that is missing those commits.")
+    print(f"           git -C {path} fetch origin {default} && git -C {path} rebase {ref}")
+
+
 def ensure_worktree(repo, name):
     """A worktree of `repo` at .claude/worktrees/<name> on branch <name>.
 
     Reused if it already exists. Otherwise created from origin's default branch
-    when that ref is known (after a best-effort fetch), else from HEAD -- so a
+    when that ref is known (after a fetch that reports its own failure),
+    else from HEAD -- so a
     deploy starts from what main actually is, not from wherever the primary
     checkout happened to be left.
     """
     path = os.path.join(repo, WORKTREES_REL, name)
+    # Fetch FIRST, and before the reuse check, so both paths judge staleness
+    # against refs that were just refreshed rather than against last week's.
+    fetch_origin(repo)
     if os.path.isdir(path) and os.path.exists(os.path.join(path, ".git")):
         print(f"worktree: using existing {os.path.relpath(path, repo)} "
               f"(branch {current_branch(path) or 'DETACHED'})")
+        report_base(repo, path)
         return path
     os.makedirs(os.path.dirname(path), exist_ok=True)
-    subprocess.run(["git", "-C", repo, "fetch", "-q", "origin"], capture_output=True)
     if git(repo, "rev-parse", "--verify", "-q", f"refs/heads/{name}", ok_fail=True):
         git(repo, "worktree", "add", path, name)
         print(f"worktree: checked out existing branch {name} at {os.path.relpath(path, repo)}")
@@ -178,6 +231,7 @@ def ensure_worktree(repo, name):
             ok_fail=True) else "HEAD"
         git(repo, "worktree", "add", "-b", name, path, base)
         print(f"worktree: created {os.path.relpath(path, repo)} on new branch {name} from {base}")
+    report_base(repo, path)
     if not is_ignored(repo, os.path.join(WORKTREES_REL, name)):
         print(f"  WARNING: {WORKTREES_REL}/ is not ignored in {repo}, so the worktree itself")
         print("           shows up as an untracked directory in the main checkout.")


### PR DESCRIPTION
Changes the catchup skill's tooling for sending entities to DeepVista, and for deploying the skill into other repos. **It does not change the weekly** — summary headings and sections still come from `entities.py render` and each repo's config.

Combines what were #17, #18 and #19.

## 1. DeepVista cards carry the whole record *(was #18)*

Each catchup entity — a meeting, a company, a theme — becomes one DeepVista card, and the code that wrote the card's text left out most of what the entity holds. On one relationship repo, 4 of 15 meeting cards named nobody. Cards now also include:

| Added to the card | Why it matters |
|---|---|
| What's owed and what's still to ask | The follow-ups from a meeting |
| Who was in the room, with roles | Who to connect across meetings |
| Whether a theme stuck, was dropped or merged, and what that cost | Whether the work lasted |
| A concept's rank | How strong a learning is |
| PRs still open, and published links | What's still in flight |

Related cards are listed by name instead of by internal ID.

Two supporting fixes:

- **`--type` filter for re-pushes.** `--category` is much broader than it sounds — on a relationship repo `category: meeting` covered 111 entities, only 15 of them actual meetings. Narrowing by type avoids paying credits to resend unchanged cards.
- **Honest docs on when cards get resent.** The push resends a card when the *entity* changed, not the card text, so a card-format change alone updates nothing. That needs a targeted `--force` re-push, and the docs now say so.

## 2. `rows` for DeepVista database cards *(was #17)*

A DeepVista database card shows a grid, and only a typed `row_of` link makes a card appear as a row. The push never created that link, so any database card pointed at our cards rendered empty.

`rows` adds them safely. Writing rows **replaces the card's entire row list**, so a careless write would delete rows someone added by hand. It:

1. Reads the current rows.
2. Adds ours and writes back the combined list.
3. Refuses to write if it couldn't read the full list.

It does nothing unless a repo sets `deepvista.databases`. It exists for the workflow later: a workflow run takes one input card, so a whole week has to be a database card with that week's cards as rows.

## 3. `deploy.py` starts branches from current `main` *(was #19)*

When deploying into another repo on a branch, the fetch ran only when creating a new worktree — reusing one skipped it — and a failed fetch said nothing. That is how two target branches ended up based on stores 28 and 19 commits old. Now it:

1. Fetches before creating *or reusing* the worktree.
2. Warns if the fetch fails.
3. Reports how many commits behind `main` the worktree is.

The warning fired on its first real run, on worktrees 40 and 150 commits behind.

## Cleanup done while combining

- **Shared code.** `push`, `fetch` and `rows` each carried the same DeepVista connection setup and the same "is sync enabled" check; each is now one function (`open_client()`, `require_enabled()`).
- **Simpler tests.** Four near-identical test stand-ins became one.
- **A bad merge caught.** Git's automatic merge mixed two groups of tests together and one failed; the test file was rebuilt from each branch's clean copy.

## Verification

- 18 tests pass.
- The `deploy.py` copies in catchup and rollup are byte-identical.
- `push`, `rows` and `fetch` parse, and both target repos were redeployed from this branch.

## Status

- Nothing has been written to DeepVista.
- The card changes (part 1) already reached the target repos through their earlier skill syncs. `rows` and the shared code follow in their own sync PRs once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)